### PR TITLE
chore: re-trigger release-please for auth packages

### DIFF
--- a/packages/pywire-auth/CHANGELOG.md
+++ b/packages/pywire-auth/CHANGELOG.md
@@ -2,4 +2,6 @@
 
 All notable changes to `pywire-auth` are documented here. This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and uses [release-please](https://github.com/googleapis/release-please) for automated releases.
 
+Initial release: batteries-included authentication — OAuth2/OIDC providers (Google, GitHub, Microsoft, Facebook, Auth0, generic OIDC), a local identity provider with Argon2 password hashing, a `SQLAlchemyAuthStore` for cross-restart persistence, policy engine with claim-based guards, `AuthActions` bundling store/session/channel mutations into one call, and a live auth channel that pushes claim changes to logged-in tabs without reload.
+
 ## Unreleased

--- a/packages/pywire-parser/src/pywire_parser/__init__.py
+++ b/packages/pywire-parser/src/pywire_parser/__init__.py
@@ -6,6 +6,7 @@ Used by pywire (core framework) and pywire-language-server.
 from pywire_parser.parser import PyWireParser
 from pywire_parser.ts_parser import parse
 from pywire_parser.ast_nodes import (
+    AuthAttribute,
     Directive,
     InterpolationNode,
     ParsedPyWire,
@@ -17,6 +18,7 @@ from pywire_parser.exceptions import PyWireSyntaxError
 __all__ = [
     "PyWireParser",
     "parse",
+    "AuthAttribute",
     "Directive",
     "InterpolationNode",
     "ParsedPyWire",

--- a/packages/pywire/src/pywire/auth/__init__.py
+++ b/packages/pywire/src/pywire/auth/__init__.py
@@ -4,6 +4,10 @@ Core abstractions shared by ``pywire-auth`` (OIDC providers, local IdP,
 database adapters) and the runtime. This module deliberately has zero
 dependencies on Starlette-level auth plumbing so it can be imported
 during codegen and at test time.
+
+Paired with the ``{$auth}`` template directive (see
+``pywire.compiler.codegen.template``) and the page-level ``!auth``
+directive, which both call through to :func:`evaluate_auth`.
 """
 
 from pywire.auth.channel import (

--- a/packages/tree-sitter-pywire/README.md
+++ b/packages/tree-sitter-pywire/README.md
@@ -1,6 +1,6 @@
 # tree-sitter-pywire
 
-Tree-sitter grammar for the PyWire `.wire` file format.
+Tree-sitter grammar for the PyWire `.wire` file format. Supports the full block-directive vocabulary including `{$if}`, `{$for}`, `{$await}`, `{$auth}`, `{$try}`, `{$snippet}`, `{$render}`, and `{$head}`.
 
 <!-- SUPPORT_MESSAGE_TEMPLATE_START -->
 ## ❤️ Support pywire


### PR DESCRIPTION
## Summary

PR #121's squash commit title contained parentheses — `feat: batteries-included auth (OIDC + local IdP + policies) (#121)` — which release-please's conventional-commits parser couldn't handle:

```
commit could not be parsed: bb852e6...
error message: Error: unexpected token '(' at 55:47, valid tokens [)]
```

Parser interpreted the first `(...)` as a conventional-commit scope, choked on `+` and spaces inside, and skipped the commit entirely. Every touched package's release-please run reported `commits: 0`, so no release PRs opened.

## Fix

Four follow-up commits, one per package, each with:
- A parseable `feat(scope):` subject line
- A `Release-As: X.Y.Z` footer forcing the intended version
- A minimal real-file touch scoped to that package (release-please attributes by path)

| Package | Version | Commit file touch |
|---|---|---|
| `pywire-auth` | `0.1.0` (initial) | `CHANGELOG.md` — initial release summary |
| `pywire` | `0.10.0 → 0.11.0` | `src/pywire/auth/__init__.py` — docstring cross-ref |
| `pywire-parser` | `0.3.0 → 0.4.0` | `src/pywire_parser/__init__.py` — export `AuthAttribute` |
| `tree-sitter-pywire` | `0.4.0 → 0.5.0` | `README.md` — block-directive list |

`docs` auto-syncs to pywire via the existing `sync-docs-release` job.

## Test plan

- [ ] Merge with a **squash commit whose title has no parentheses** (e.g. `chore: re-trigger release-please for auth packages`)
- [ ] After merge, confirm release-please opens four release PRs at the versions above