### PR TITLE
chore: re-trigger release-please (merge commit, not squash)

### DIFF
--- a/packages/pywire-auth/CHANGELOG.md
+++ b/packages/pywire-auth/CHANGELOG.md
@@ -5,3 +5,5 @@ All notable changes to `pywire-auth` are documented here. This project follows [
 Initial release: batteries-included authentication — OAuth2/OIDC providers (Google, GitHub, Microsoft, Facebook, Auth0, generic OIDC), a local identity provider with Argon2 password hashing, a `SQLAlchemyAuthStore` for cross-restart persistence, policy engine with claim-based guards, `AuthActions` bundling store/session/channel mutations into one call, and a live auth channel that pushes claim changes to logged-in tabs without reload.
 
 ## Unreleased
+
+_Release PR tracked by release-please._

--- a/packages/pywire-parser/src/pywire_parser/__init__.py
+++ b/packages/pywire-parser/src/pywire_parser/__init__.py
@@ -1,6 +1,8 @@
 """PyWire parser — shared parsing library for .wire files.
 
-Used by pywire (core framework) and pywire-language-server.
+Used by pywire (core framework) and pywire-language-server. AST nodes
+include block-directive markers such as ``AuthAttribute`` that mirror
+the tree-sitter-pywire grammar.
 """
 
 from pywire_parser.parser import PyWireParser

--- a/packages/pywire/src/pywire/auth/__init__.py
+++ b/packages/pywire/src/pywire/auth/__init__.py
@@ -8,6 +8,9 @@ during codegen and at test time.
 Paired with the ``{$auth}`` template directive (see
 ``pywire.compiler.codegen.template``) and the page-level ``!auth``
 directive, which both call through to :func:`evaluate_auth`.
+
+Live claim updates flow via :class:`AuthChannel` over the WebSocket
+connection, marking ``{$auth}`` regions dirty for re-evaluation.
 """
 
 from pywire.auth.channel import (

--- a/packages/tree-sitter-pywire/README.md
+++ b/packages/tree-sitter-pywire/README.md
@@ -2,6 +2,8 @@
 
 Tree-sitter grammar for the PyWire `.wire` file format. Supports the full block-directive vocabulary including `{$if}`, `{$for}`, `{$await}`, `{$auth}`, `{$try}`, `{$snippet}`, `{$render}`, and `{$head}`.
 
+Consumed by `pywire-parser` (via py-tree-sitter), the VS Code extension, and the Prettier plugin.
+
 <!-- SUPPORT_MESSAGE_TEMPLATE_START -->
 ## ❤️ Support pywire
 


### PR DESCRIPTION
## Summary

Previous attempt in #138 was squash-merged, collapsing the 4 commits with \`Release-As:\` footers into one \`chore:\` commit that release-please ignored.

This PR must be merged as a **merge commit** (not squash) so all 4 commits land individually on main with their footers intact.

## Commits

- \`feat(pywire-auth):\` — Release-As: 0.1.0
- \`feat(pywire):\` — Release-As: 0.11.0
- \`feat(pywire-parser):\` — Release-As: 0.4.0
- \`feat(tree-sitter-pywire):\` — Release-As: 0.5.0

## Test plan

- [ ] Merge as **merge commit** via \`gh pr merge --merge --admin\`
- [ ] Confirm release-please opens four release PRs