### PR TITLE
chore: track pywire-auth in release-please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,6 +12,10 @@
       "release-type": "python",
       "component": "pywire-parser"
     },
+    "packages/pywire-auth": {
+      "release-type": "python",
+      "component": "pywire-auth"
+    },
     "packages/pywire-language-server": {
       "release-type": "python",
       "component": "pywire-language-server"


### PR DESCRIPTION
Missing entry caused release-please to silently skip pywire-auth in #139's run despite the manifest having it at 0.1.0 and a feat(pywire-auth) commit on main. This adds the config entry so the next release-please run picks up the existing feat commit.