### PR TITLE
fix(pywire-auth): public-API docstring + add PyPI publish job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,8 @@ jobs:
       pywire--tag_name: ${{ steps.release.outputs['packages/pywire--tag_name'] }}
       pywire-parser--release_created: ${{ steps.release.outputs['packages/pywire-parser--release_created'] }}
       pywire-parser--tag_name: ${{ steps.release.outputs['packages/pywire-parser--tag_name'] }}
+      pywire-auth--release_created: ${{ steps.release.outputs['packages/pywire-auth--release_created'] }}
+      pywire-auth--tag_name: ${{ steps.release.outputs['packages/pywire-auth--tag_name'] }}
       pywire-language-server--release_created: ${{ steps.release.outputs['packages/pywire-language-server--release_created'] }}
       pywire-language-server--tag_name: ${{ steps.release.outputs['packages/pywire-language-server--tag_name'] }}
       vscode-pywire--release_created: ${{ steps.release.outputs['packages/vscode-pywire--release_created'] }}
@@ -279,6 +281,23 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: packages/pywire-parser/dist/
+
+  # Build and publish pywire-auth (pure Python)
+  publish-pywire-auth:
+    name: "Publish pywire-auth to PyPI"
+    needs: release-please
+    if: needs.release-please.outputs.pywire-auth--release_created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv build --out-dir dist
+        working-directory: packages/pywire-auth
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: packages/pywire-auth/dist/
 
   # Publish language server to PyPI
   publish-language-server:

--- a/packages/pywire-auth/src/pywire_auth/__init__.py
+++ b/packages/pywire-auth/src/pywire_auth/__init__.py
@@ -3,11 +3,16 @@
 Public API:
 
 - :func:`connect_auth` — single integration entry point
+- :class:`AuthActions` — one-call claim/session mutations (`app.state.auth`)
 - :class:`AuthMiddleware` — ASGI middleware that populates scope['user']
-- Providers: :class:`GoogleProvider`, :class:`GitHubProvider`,
-  :class:`GenericOIDCProvider`
-- Store adapters: :class:`MemoryAuthStore`
-- Structural interfaces: :class:`AuthStore`, :class:`OIDCProvider`
+- :class:`LocalIdP` + :class:`TokenIssuer` — database-backed local provider
+- OIDC providers: :class:`GoogleProvider`, :class:`GitHubProvider`,
+  :class:`MicrosoftProvider`, :class:`FacebookProvider`,
+  :class:`Auth0Provider`, :class:`GenericOIDCProvider`
+- Store adapters: :class:`MemoryAuthStore`, :class:`SQLAlchemyAuthStore`
+  (requires ``pip install pywire-auth[sqlalchemy]``)
+- Structural interfaces: :class:`AuthStore`, :class:`OIDCProvider`,
+  :class:`BaseOAuth2Provider`, :class:`BaseOIDCProvider`
 """
 
 from pywire_auth._protocols import AuthStore, OIDCProvider


### PR DESCRIPTION
## Summary

- Adds the missing \`publish-pywire-auth\` job to \`.github/workflows/release.yml\` so pywire-auth tags actually publish to PyPI. Follows the pure-Python pattern from \`publish-pywire-parser\`.
- Adds \`pywire-auth--release_created\` + \`--tag_name\` outputs to the \`release-please\` job.
- Fixes the incomplete \`Public API\` listing in the package module docstring — now enumerates all exported symbols.

## Notes

Releasing #144 (currently pywire-auth 0.1.0) after this lands will trigger the new publish job and cut the first PyPI release. Trusted Publishing must be configured on PyPI for \`pywire-auth\` before #144 is merged.

## Test plan

- [ ] Squash-merge; confirm release-please updates #144 to include this fix in the changelog
- [ ] Merge #144; confirm \`publish-pywire-auth\` runs and PyPI receives the wheel