### PR TITLE
fix(pywire): strip ANSI + Rich markup from browser-forwarded logs

### DIFF
--- a/packages/pywire/src/pywire/runtime/dev_server.py
+++ b/packages/pywire/src/pywire/runtime/dev_server.py
@@ -9,8 +9,11 @@ import logging
 from rich.console import Console
 from rich.text import Text
 
-# Force terminal to ensure ANSI codes are generated even when piped to TUI
-console = Console(force_terminal=True, markup=True)
+# Force terminal to ensure ANSI codes are generated even when piped to TUI.
+# Write to the real stdout so Rich output bypasses the per-request stdout
+# interceptor — ANSI stays in the terminal, and the browser gets clean
+# messages via BrowserLogForwarder instead.
+console = Console(force_terminal=True, markup=True, file=sys.__stdout__)
 
 # Module-level logger — handler/level configured in run_dev_server() at startup
 _dev_logger = logging.getLogger("pywire.dev")
@@ -263,9 +266,26 @@ async def run_dev_server(
             pywire_src_dir = Path(pywire.__file__).parent
 
             # Install logging interceptor for print capture
-            from pywire.runtime.logging import install_logging_interceptor
+            from pywire.runtime.logging import (
+                install_browser_log_forwarder,
+                install_logging_interceptor,
+            )
 
             install_logging_interceptor()
+            # Forward structured log records (no ANSI, no Rich markup) to any
+            # per-request log callback set via log_callback_ctx.
+            install_browser_log_forwarder(
+                [
+                    "",  # root
+                    "pywire.dev",
+                    "uvicorn",
+                    "uvicorn.error",
+                    "uvicorn.access",
+                    "hypercorn",
+                    "hypercorn.error",
+                    "hypercorn.access",
+                ]
+            )
 
             if not pages_dir.exists():
                 _dev_logger.warning(

--- a/packages/pywire/src/pywire/runtime/logging.py
+++ b/packages/pywire/src/pywire/runtime/logging.py
@@ -35,9 +35,12 @@ class ContextAwareStdout:
             # Schedule the callback. Strip ANSI via Rich's structured parser
             # so user code that prints colored output still renders cleanly
             # in the browser console.
-            try:
-                plain = Text.from_ansi(message).plain
-            except Exception:
+            if "\x1b" in message:
+                try:
+                    plain = Text.from_ansi(message).plain
+                except Exception:
+                    plain = message
+            else:
                 plain = message
             try:
                 loop = asyncio.get_running_loop()

--- a/packages/pywire/src/pywire/runtime/logging.py
+++ b/packages/pywire/src/pywire/runtime/logging.py
@@ -1,8 +1,11 @@
 import asyncio
 import contextvars
 import io
+import logging
 import sys
-from typing import IO, Any, Callable, Coroutine
+from typing import IO, Any, Callable, Coroutine, Iterable
+
+from rich.text import Text
 
 # Context variable to hold the log callback for the current request/session
 # Callback signature: async def callback(message: str)
@@ -29,12 +32,17 @@ class ContextAwareStdout:
         # Check context for callback
         callback = log_callback_ctx.get()
         if callback:
-            # Schedule the callback
-            # Since write is sync, we must schedule async task
+            # Schedule the callback. Strip ANSI via Rich's structured parser
+            # so user code that prints colored output still renders cleanly
+            # in the browser console.
+            try:
+                plain = Text.from_ansi(message).plain
+            except Exception:
+                plain = message
             try:
                 loop = asyncio.get_running_loop()
                 if loop.is_running():
-                    loop.create_task(self._safe_callback(callback, message))
+                    loop.create_task(self._safe_callback(callback, plain))
             except RuntimeError:
                 # No running loop, can't stream
                 pass
@@ -70,3 +78,68 @@ def install_logging_interceptor() -> None:
         # Handle stderr too? Usually yes for errors.
         sys.stderr = ContextAwareStdout(sys.stderr, level="error")
         _installed = True
+
+
+_LEVEL_NAME_MAP = {
+    logging.DEBUG: "debug",
+    logging.INFO: "info",
+    logging.WARNING: "warn",
+    logging.ERROR: "error",
+    logging.CRITICAL: "error",
+}
+
+
+class BrowserLogForwarder(logging.Handler):
+    """Forwards structured LogRecords to the browser via log_callback_ctx.
+
+    Uses record.getMessage() (no ANSI) and strips Rich markup tokens via
+    Text.from_markup, so the browser receives plain text regardless of how
+    the parent handler renders to the terminal.
+    """
+
+    def emit(self, record: logging.LogRecord) -> None:
+        callback = log_callback_ctx.get()
+        if callback is None:
+            return
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return
+        if not loop.is_running():
+            return
+        try:
+            raw = record.getMessage()
+            try:
+                plain = Text.from_markup(raw).plain
+            except Exception:
+                plain = raw
+            level = _LEVEL_NAME_MAP.get(record.levelno, "info")
+            loop.create_task(_forward_to_callback(callback, plain, level))
+        except Exception:
+            self.handleError(record)
+
+
+async def _forward_to_callback(
+    callback: Callable[..., Any], message: str, level: str
+) -> None:
+    try:
+        import inspect
+
+        sig = inspect.signature(callback)
+        if "level" in sig.parameters:
+            await callback(message, level=level)
+        else:
+            await callback(message)
+    except Exception:
+        pass
+
+
+def install_browser_log_forwarder(logger_names: Iterable[str]) -> BrowserLogForwarder:
+    """Attach a BrowserLogForwarder to each named logger (deduped)."""
+    handler = BrowserLogForwarder()
+    handler.setLevel(logging.DEBUG)
+    for name in logger_names:
+        lg = logging.getLogger(name) if name else logging.getLogger()
+        if not any(isinstance(h, BrowserLogForwarder) for h in lg.handlers):
+            lg.addHandler(handler)
+    return handler


### PR DESCRIPTION
## Summary
- Route the dev Rich Console at `sys.__stdout__` so ANSI output bypasses the per-request stdout interceptor.
- Add `BrowserLogForwarder` logging handler that forwards structured `LogRecord` messages (no ANSI) with Rich markup stripped via `Text.from_markup`, through `log_callback_ctx`.
- Installed on root, `pywire.dev`, `uvicorn*`, and `hypercorn*` in `run_dev_server`.
- `ContextAwareStdout` still covers user `print()` capture and now passes messages through `Text.from_ansi` (structured, not regex) to clean any stray escapes from user code.

## Test plan
- [ ] Run dev server, trigger a request, verify browser devtools console shows plain text (no `\x1b[32m…` prefixes).
- [ ] Terminal output still rendered with Rich colors/markup.
- [ ] User `print("hello")` from a page handler still reaches the browser console.
- [ ] Uvicorn access logs visible in browser without ANSI.