### PR TITLE
fix(pywire): lazy-import rich in runtime logging

### DIFF
--- a/packages/pywire/src/pywire/runtime/logging.py
+++ b/packages/pywire/src/pywire/runtime/logging.py
@@ -5,8 +5,6 @@ import logging
 import sys
 from typing import IO, Any, Callable, Coroutine, Iterable
 
-from rich.text import Text
-
 # Context variable to hold the log callback for the current request/session
 # Callback signature: async def callback(message: str)
 log_callback_ctx: contextvars.ContextVar[
@@ -37,6 +35,8 @@ class ContextAwareStdout:
             # in the browser console.
             if "\x1b" in message:
                 try:
+                    from rich.text import Text
+
                     plain = Text.from_ansi(message).plain
                 except Exception:
                     plain = message
@@ -113,6 +113,8 @@ class BrowserLogForwarder(logging.Handler):
         try:
             raw = record.getMessage()
             try:
+                from rich.text import Text
+
                 plain = Text.from_markup(raw).plain
             except Exception:
                 plain = raw


### PR DESCRIPTION
## Summary
- Root cause of the language-server CI failure on main: the previous PR added a top-level \`from rich.text import Text\` to \`pywire/runtime/logging.py\`, which is in the app init path (\`websocket.py\` imports \`log_callback_ctx\`). Language-server's nox session installs pywire without dev extras, so \`rich\` isn't available and import fails.
- Fix: move both \`Text.from_ansi\` (ContextAwareStdout) and \`Text.from_markup\` (BrowserLogForwarder) imports to point-of-use. Rich is only touched when a browser log callback is active — dev mode, where \`rich\` is already present via \`rich-click\`.
- No new runtime dependency added to pywire core.

## Test plan
- [ ] Language Server CI job passes.
- [ ] Core pywire tests still pass (\`test_logging_stream.py\` verified locally).