### PR TITLE
feat: $dynamic memo escape, !no_interactive, component memo, class/style bind, oneliner blocks

### DIFF
--- a/docs/src/content/docs/concepts/wire-file.md
+++ b/docs/src/content/docs/concepts/wire-file.md
@@ -44,3 +44,31 @@ The HTML block supports:
 - **Attributes**: `attr={value}` or `{attr}`
 - **Events**: `@click={handler}`
 - **Control Flow**: `$if`, `$for`
+
+## Page Directives
+
+Directives are line-level metadata declared above the Python block. They configure how the page is routed, rendered, or wired up at runtime.
+
+| Directive         | Purpose                                                                              |
+| ----------------- | ------------------------------------------------------------------------------------ |
+| `!path "..."`     | Sets the URL pattern this page handles.                                              |
+| `!layout "..."`   | Wraps the page in a parent layout.                                                   |
+| `!auth ...`       | Gates the page on an auth policy.                                                    |
+| `!no_spa`         | Opts the page out of SPA navigation; renders as a full-page reload.                  |
+| `!no_interactive` | Renders the page as static HTML — skips event handlers and ref wiring on the client. |
+
+### `!no_interactive`
+
+Mark a page as fully static for the client: no event handlers wire up, no refs, no per-handler dispatch. The WebSocket **stays connected** (so SPA navigation back to an interactive page resumes seamlessly without reconnecting), but the page itself behaves as plain HTML.
+
+Use it for pages that don't need interactivity — marketing pages, docs, error pages — to avoid paying for client-side bookkeeping.
+
+```pywire
+!path "/about"
+!no_interactive
+
+<h1>About PyWire</h1>
+<p>Server-rendered. No JS handlers attached.</p>
+```
+
+`@click`, `@input`, etc. still parse, but the client ignores them on this page. Forms continue to work via standard HTTP submit (PyWire's form-submit interception is bypassed).

--- a/docs/src/content/docs/guides/forms.md
+++ b/docs/src/content/docs/guides/forms.md
@@ -101,9 +101,9 @@ When validation fails, errors are available on the form ref's `errors` namespace
 
 You can bind validation attributes dynamically.
 
-```html
+```pywire
 <!-- Field is required only if 'is_company' checkbox is checked -->
-<input name="company_name" required="{is_company}" />
+<input name="company_name" required={is_company} />
 ```
 
 ## Pydantic Model Integration

--- a/docs/src/content/docs/guides/your-first-component.md
+++ b/docs/src/content/docs/guides/your-first-component.md
@@ -37,9 +37,9 @@ def increment():
 ---
 <h1>Count: {count}</h1>
 
-<button @click="{increment}" $disabled="{count >= 10}"> Increment (Max 10)</button>
+<button @click={increment} $disabled={count >= 10}> Increment (Max 10)</button>
 
-<p $show="{count > 5}" style="color: red;"> High count alert!</p>
+<p $show={count > 5} style="color: red;"> High count alert!</p>
 ```
 
 In the next sections, we'll dive deeper into the `.wire` file format and how reactivity works.

--- a/docs/src/content/docs/reference/api.md
+++ b/docs/src/content/docs/reference/api.md
@@ -366,13 +366,13 @@ Also available as `$event` for compatibility with other frameworks.
 
 **Example:**
 
-```html
+```pywire
 <!-- Accessing input value -->
-<input @input="{update_text(event.value)}" />
+<input @input={update_text(event.value)} />
 
 <!-- Accessing specific key press -->
-<input @keydown="{handle_key(event.key)}" />
+<input @keydown={handle_key(event.key)} />
 
 <!-- Debugging event data -->
-<button @click="{print(event.id, event.type)}">Debug</button>
+<button @click={print(event.id, event.type)}>Debug</button>
 ```

--- a/docs/src/content/docs/syntax/blocks.md
+++ b/docs/src/content/docs/syntax/blocks.md
@@ -335,4 +335,74 @@ The `{$head}` block teleports its contents into the document `<head>`, regardles
 - **Title:** the last `<title>` contributed by the render tree wins. Earlier titles are stripped.
 - **Everything else:** preserved in authored order. If a page contributes `<meta charset>` before `<title>`, the charset stays first.
 
+## Memoization Escape (`{$dynamic}`)
+
+---
+
+PyWire memoizes regions, snippets, and components by default — they only re-render when the wires they read change (or, for snippets, when their args change). This is a free perf win for pure markup, but breaks impure work like `datetime.now()`, `random.choice()`, side-effecting counters, or per-render UUIDs.
+
+The `{$dynamic}` block opts a region of template out of memoization. Anything inside re-runs every render, regardless of wire/arg equality.
+
+### Syntax
+
+```pywire
+{$dynamic}
+    <!-- contents re-render every cycle -->
+{/dynamic}
+```
+
+### Examples
+
+**Impure expression:**
+
+```pywire
+<p>Last rendered: {$dynamic}{datetime.now().isoformat()}{/dynamic}</p>
+```
+
+**Bypass snippet memoization:**
+
+```pywire
+{$snippet row(x)}
+    <li>{x} ({uuid.uuid4()})</li>
+{/snippet}
+
+<!-- Memoized: same args → same row, uuid frozen on first render. -->
+<ul>{$render row(1)}</ul>
+
+<!-- Bypassed: row body re-runs every render, fresh uuid each time. -->
+<ul>{$dynamic}{$render row(1)}{/dynamic}</ul>
+```
+
+**Bypass component memoization:**
+
+```pywire
+<!-- card body re-runs only when its props or wires change -->
+<Counter label="card-A" initial={a.value} />
+
+<!-- card body re-runs every page render -->
+{$dynamic}
+    <Counter label="always-fresh" initial={a.value} />
+{/dynamic}
+```
+
+### Notes
+
+- The escape is **caller-side**: wrap each call site that needs to be impure. Defining a snippet or component as inherently dynamic isn't supported — that's intentional, since memoization safety is a property of how a thing is used, not how it's defined.
+- The bypass applies to the entire subtree: snippets, regions, components, and slot content all get re-rendered.
+- Wires inside `{$dynamic}` still update reactively. The block only suppresses the memo wrapper, not reactivity.
+
+## Oneliner Blocks
+
+---
+
+Paired blocks (`{$if}`, `{$for}`, `{$with}`, `{$dynamic}`) can be written on a single line when the body is short:
+
+```pywire
+{$if user.is_admin}<AdminBadge />{/if}
+{$for tag in tags, key=tag}<span class="tag">{tag}</span>{/for}
+<p>{$dynamic}{datetime.now()}{/dynamic}</p>
+```
+
+Multi-line form is still preferred for non-trivial bodies — oneliner is an ergonomic shortcut, not a separate construct.
+
 This makes layouts hands-off — they don't need to know which pages want a particular meta tag.

--- a/docs/src/content/docs/syntax/templating.md
+++ b/docs/src/content/docs/syntax/templating.md
@@ -67,6 +67,45 @@ id = "main-image"
 <img {src} {id} />
 ```
 
+### `class` and `style` Bindings
+
+The `class` and `style` attributes accept structured values in addition to plain strings, so you don't have to build the string yourself.
+
+**`class`:**
+
+- **String** — passes through unchanged.
+- **List / tuple** — truthy items are space-joined; falsy items are dropped.
+- **Dict** — keys whose values are truthy are space-joined.
+
+```pywire
+---
+is_active = wire(True)
+is_disabled = wire(False)
+size = wire("lg")
+---
+<!-- list form -->
+<button class={["btn", size, is_active and "active"]}>Click</button>
+
+<!-- dict form (the most readable for many flags) -->
+<button class={{"btn": True, "active": is_active, "disabled": is_disabled}}>
+    Click
+</button>
+```
+
+**`style`:**
+
+- **String** — passes through unchanged.
+- **Dict** — `key: value` pairs are joined with `;`. Entries with `None` values are dropped.
+
+```pywire
+---
+theme = wire("dark")
+---
+<div style={{"color": "red", "background": theme, "border": None}}>
+    Styled content
+</div>
+```
+
 ### Boolean Attributes
 
 Framework attributes like `$disabled`, `$checked`, and `$readonly` accept a boolean expression and add or remove the attribute accordingly.

--- a/packages/pywire-parser/pyproject.toml
+++ b/packages/pywire-parser/pyproject.toml
@@ -13,7 +13,7 @@ requires-python = ">=3.11"
 license = "MIT"
 dependencies = [
     "tree-sitter>=0.23",
-    "tree-sitter-pywire>=0.3.0",
+    "tree-sitter-pywire>=0.5.0",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/packages/pywire-parser/src/pywire_parser/ast_nodes.py
+++ b/packages/pywire-parser/src/pywire_parser/ast_nodes.py
@@ -40,6 +40,14 @@ class NoSpaDirective(Directive):
 
 
 @dataclass
+class NoInteractiveDirective(Directive):
+    """!no_interactive - render this page statically; keep WS connection alive but skip event/wire wiring for this page."""
+
+    def __str__(self) -> str:
+        return "NoInteractiveDirective()"
+
+
+@dataclass
 class LayoutDirective(Directive):
     """!layout "path/to/layout.pywire" """
 
@@ -252,6 +260,18 @@ class HeadAttribute(SpecialAttribute):
 
     def __str__(self) -> str:
         return "HeadAttribute()"
+
+
+@dataclass
+class DynamicAttribute(SpecialAttribute):
+    """{$dynamic}...{/dynamic} — opt the wrapped subtree out of memoization.
+
+    Bypasses RenderUnit caching for any region/snippet/slot/component
+    rendered inside the block. Body lives in parent TemplateNode.children.
+    """
+
+    def __str__(self) -> str:
+        return "DynamicAttribute()"
 
 
 @dataclass

--- a/packages/pywire-parser/src/pywire_parser/directives/__init__.py
+++ b/packages/pywire-parser/src/pywire_parser/directives/__init__.py
@@ -3,6 +3,7 @@
 from pywire_parser.directives.auth import AuthDirectiveParser
 from pywire_parser.directives.base import DirectiveParser
 from pywire_parser.directives.layout import LayoutDirectiveParser
+from pywire_parser.directives.no_interactive import NoInteractiveDirectiveParser
 from pywire_parser.directives.no_spa import NoSpaDirectiveParser
 from pywire_parser.directives.path import PathDirectiveParser
 
@@ -10,6 +11,7 @@ __all__ = [
     "AuthDirectiveParser",
     "DirectiveParser",
     "LayoutDirectiveParser",
+    "NoInteractiveDirectiveParser",
     "NoSpaDirectiveParser",
     "PathDirectiveParser",
 ]

--- a/packages/pywire-parser/src/pywire_parser/directives/no_interactive.py
+++ b/packages/pywire-parser/src/pywire_parser/directives/no_interactive.py
@@ -1,0 +1,31 @@
+"""No-interactive directive parser."""
+
+import re
+from typing import Optional
+
+from pywire_parser.ast_nodes import NoInteractiveDirective
+from pywire_parser.directives.base import DirectiveParser
+
+
+class NoInteractiveDirectiveParser(DirectiveParser):
+    """Parses !no_interactive directive — page renders statically.
+
+    The framework still keeps the WebSocket connection alive across SPA
+    navigation, but skips event-handler binding and wire wiring for this
+    page so client→server interactivity is fully inert here.
+    """
+
+    PATTERN = re.compile(r"^!no_interactive\s*$")
+
+    def can_parse(self, line: str) -> bool:
+        return line.strip() == "!no_interactive"
+
+    def parse(
+        self, line: str, line_num: int, col_num: int
+    ) -> Optional[NoInteractiveDirective]:
+        if not self.PATTERN.match(line.strip()):
+            return None
+
+        return NoInteractiveDirective(
+            name="no_interactive", line=line_num, column=col_num
+        )

--- a/packages/pywire-parser/src/pywire_parser/parser.py
+++ b/packages/pywire-parser/src/pywire_parser/parser.py
@@ -11,6 +11,7 @@ from pywire_parser.ast_nodes import (
     AuthAttribute,
     AwaitAttribute,
     CatchAttribute,
+    DynamicAttribute,
     ElifAttribute,
     ElseAttribute,
     ExceptAttribute,
@@ -37,6 +38,7 @@ from pywire_parser.attributes.loop import KeyAttributeParser, LoopAttributeParse
 from pywire_parser.directives.auth import AuthDirectiveParser
 from pywire_parser.directives.base import DirectiveParser
 from pywire_parser.directives.layout import LayoutDirectiveParser
+from pywire_parser.directives.no_interactive import NoInteractiveDirectiveParser
 from pywire_parser.directives.no_spa import NoSpaDirectiveParser
 from pywire_parser.directives.path import PathDirectiveParser
 from pywire_parser.exceptions import PyWireSyntaxError
@@ -113,6 +115,7 @@ class PyWireParser:
         self.directive_parsers: List[DirectiveParser] = [
             PathDirectiveParser(),
             NoSpaDirectiveParser(),
+            NoInteractiveDirectiveParser(),
             LayoutDirectiveParser(),
             AuthDirectiveParser(),
         ]
@@ -262,6 +265,7 @@ class PyWireParser:
             AuthAttribute,
             SnippetAttribute,
             HeadAttribute,
+            DynamicAttribute,
         )
 
         for node in nodes:
@@ -492,6 +496,12 @@ class PyWireParser:
         elif kw == "head":
             node.special_attributes.append(
                 HeadAttribute(name="$head", value="", line=rn.line, column=rn.column)
+            )
+        elif kw == "dynamic":
+            node.special_attributes.append(
+                DynamicAttribute(
+                    name="$dynamic", value="", line=rn.line, column=rn.column
+                )
             )
 
     def _validate_block_root(self, node: TemplateNode) -> None:

--- a/packages/pywire/noxfile.py
+++ b/packages/pywire/noxfile.py
@@ -6,4 +6,10 @@ nox.options.sessions = ["tests"]
 @nox.session(python=["3.11", "3.12", "3.13", "3.14"], venv_backend="uv")
 def tests(session):
     session.install(".[dev]")
+    # Install the chromium browser for the playwright version this session
+    # just resolved. The outer CI venv may have a different playwright
+    # version than what `[dev]` resolves to here, leading to a browser
+    # cache version mismatch (e.g. outer downloads chromium-1208, nox
+    # session expects chromium-1217).
+    session.run("playwright", "install", "chromium")
     session.run("pytest", *session.posargs)

--- a/packages/pywire/src/pywire/client/src/core/app.ts
+++ b/packages/pywire/src/pywire/client/src/core/app.ts
@@ -27,6 +27,13 @@ export interface PyWireConfig extends TransportConfig {
   reconnectOverlay?: boolean
   /** When false, no WebSocket/transport is used — SPA navigation via HTTP fetch */
   interactive?: boolean
+  /**
+   * Per-page opt-out of interactivity (`!no_interactive` directive).
+   * When false, the WebSocket stays connected (so SPA navigation back to
+   * an interactive page is seamless), but event handlers, wire
+   * subscriptions, and ref tracking are NOT wired up for the current page.
+   */
+  pageInteractive?: boolean
 }
 
 const DEFAULT_CONFIG: PyWireConfig = {
@@ -36,6 +43,7 @@ const DEFAULT_CONFIG: PyWireConfig = {
   enableHTTP: true,
   debug: false,
   interactive: true,
+  pageInteractive: true,
 }
 
 /**
@@ -160,8 +168,13 @@ export class PyWireApp {
 
     this.setupSPANavigation()
 
-    // Event delegation runs in both modes — SSR needs it so `@submit`
-    // handlers swap the form submit for `httpFormSubmit` (fetch + morph).
+    // Event delegation + ref wiring run in both modes. The handlers
+    // themselves runtime-check `pageInteractive` at dispatch time
+    // (handler.ts), so attaching them up-front is harmless on a
+    // non-interactive page and ensures they're already wired when SPA
+    // nav lands on an interactive page later. Avoids the bug where
+    // hard-loading a `!no_interactive` page leaves events unbound for
+    // the rest of the SPA session.
     this.eventHandler.init()
     this.refManager.init()
 
@@ -232,6 +245,9 @@ export class PyWireApp {
         this.mountPath = typeof meta.mount_path === 'string' ? meta.mount_path : ''
         if (meta.interactive !== undefined) {
           this.config.interactive = !!meta.interactive
+        }
+        if (meta.page_interactive !== undefined) {
+          this.config.pageInteractive = !!meta.page_interactive
         }
         if (meta.debug !== undefined) {
           this.config.debug = !!meta.debug
@@ -467,6 +483,9 @@ export class PyWireApp {
       const html = await response.text()
       this.updater.update(html)
       this.eventHandler?.refreshListeners()
+      // The new page may have a different `!no_interactive` setting —
+      // re-read the meta script so the per-page flag is current.
+      this.loadSPAMetadata()
 
       document.dispatchEvent(
         new CustomEvent('pywire:navigate', {
@@ -575,6 +594,19 @@ export class PyWireApp {
         } else if (msg.html) {
           this.updater.update(msg.html)
           this.eventHandler.refreshListeners()
+          // Full HTML replacement (e.g. WS-driven PJAX nav) — re-read meta
+          // so per-page `!no_interactive` flag tracks the current page.
+          this.loadSPAMetadata()
+        }
+
+        // Per-update meta (sent by server `render_update`) — keeps
+        // `pageInteractive` in sync after SPA nav, since SPA-nav responses
+        // (regions or fragment) don't include the `_pywire_spa_meta`
+        // script tag the client otherwise reads.
+        if (msg.meta && typeof msg.meta === 'object') {
+          if (msg.meta.page_interactive !== undefined) {
+            this.config.pageInteractive = !!msg.meta.page_interactive
+          }
         }
 
         // If this update was triggered by a PJAX navigation (relocate),

--- a/packages/pywire/src/pywire/client/src/core/dom-updater.ts
+++ b/packages/pywire/src/pywire/client/src/core/dom-updater.ts
@@ -221,6 +221,13 @@ export class DOMUpdater {
     const extracted: { script: HTMLScriptElement; inPermanent: boolean }[] = []
 
     for (const script of scripts) {
+      // Leave PyWire's JSON metadata script in place so morphdom can
+      // update its content from the new HTML — otherwise SPA nav between
+      // pages with different `!no_interactive` flags ends up with stale
+      // meta because the old script is preserved by onBeforeNodeDiscarded
+      // and the new one was extracted out before morphdom ran.
+      if (script.id === '_pywire_spa_meta') continue
+
       // Check if this script is inside a data-pw-permanent element
       const inPermanent = !!script.closest('[data-pw-permanent]')
       extracted.push({ script, inPermanent })

--- a/packages/pywire/src/pywire/client/src/core/transports/base.ts
+++ b/packages/pywire/src/pywire/client/src/core/transports/base.ts
@@ -70,6 +70,7 @@ export interface ServerMessage {
   commands?: Command[]
   session_id?: string
   session_restored?: boolean
+  meta?: { page_interactive?: boolean; [key: string]: unknown }
 }
 
 export interface NavigateMessage {

--- a/packages/pywire/src/pywire/client/src/events/handler.ts
+++ b/packages/pywire/src/pywire/client/src/events/handler.ts
@@ -146,6 +146,14 @@ export class UnifiedEventHandler {
    * Main event handler.
    */
   private async handleEvent(e: Event): Promise<void> {
+    // Per-page !no_interactive opt-out. The flag may flip between SPA
+    // navigations, so check at dispatch time. The handler stays attached
+    // (cheap) but we ignore events while the current page declares itself
+    // non-interactive.
+    if (this.app.getConfig().pageInteractive === false) {
+      return
+    }
+
     const eventType = e.type
 
     // File inputs can retain a prior custom validity error unless we clear it

--- a/packages/pywire/src/pywire/compiler/codegen/generator.py
+++ b/packages/pywire/src/pywire/compiler/codegen/generator.py
@@ -9,6 +9,7 @@ from pywire.compiler.ast_nodes import (
     Directive,
     EventAttribute,
     LayoutDirective,
+    NoInteractiveDirective,
     NoSpaDirective,
     ParsedPyWire,
     PathDirective,
@@ -1025,6 +1026,18 @@ class CodeGenerator:
             )
         )
 
+        # !no_interactive — page renders statically; WS stays connected
+        # but client skips event/wire wiring for this page.
+        no_interactive = (
+            parsed.get_directive_by_type(NoInteractiveDirective) is not None
+        )
+        stmts.append(
+            ast.Assign(
+                targets=[ast.Name(id="__no_interactive__", ctx=ast.Store())],
+                value=ast.Constant(value=bool(no_interactive)),
+            )
+        )
+
         # __sibling_paths__ = ['/path1', '/path2', ...]
         if path_directive and not path_directive.is_simple_string:
             paths = list(path_directive.routes.values())
@@ -1880,5 +1893,23 @@ class CodeGenerator:
                     value=ast.Dict(keys=region_keys, values=region_vals),
                 )
             )
+
+            dyn = self.template_codegen.dynamic_regions
+            if dyn:
+                binding_funcs.append(
+                    ast.Assign(
+                        targets=[ast.Name(id="__dynamic_regions__", ctx=ast.Store())],
+                        value=ast.Call(
+                            func=ast.Name(id="frozenset", ctx=ast.Load()),
+                            args=[
+                                ast.Tuple(
+                                    elts=[ast.Constant(value=r) for r in sorted(dyn)],
+                                    ctx=ast.Load(),
+                                )
+                            ],
+                            keywords=[],
+                        ),
+                    )
+                )
 
         return render_func, binding_funcs

--- a/packages/pywire/src/pywire/compiler/codegen/template.py
+++ b/packages/pywire/src/pywire/compiler/codegen/template.py
@@ -19,6 +19,7 @@ from pywire.compiler.ast_nodes import (
     ExceptAttribute,
     FinallyAttribute,
     ForAttribute,
+    DynamicAttribute,
     HeadAttribute,
     IfAttribute,
     InterpolationNode,
@@ -63,8 +64,25 @@ class TemplateCodegen:
         self._region_counter = 0
         self._region_id_prefix = ""
         self.region_renderers: Dict[str, str] = {}
+        # Region IDs whose codegen happened under `{$dynamic}`. These regions
+        # are force-marked dirty in `render_update` so the bypass kwarg on
+        # inner `_invoke_render`/`_invoke_component` calls actually executes.
+        self.dynamic_regions: Set[str] = set()
+        # Stack of region IDs being codegen'd. Pushed when entering
+        # `_generate_region_method`, popped on exit. Used by the
+        # `DynamicAttribute` branch to tag the *enclosing* region as
+        # dynamic (so impure expressions adjacent to a `{$dynamic}` block
+        # in the same region still re-execute every cycle).
+        self._region_codegen_stack: List[str] = []
         self._expr_id_counter = 0
         self._wire_vars: Set[str] = set()
+        # Codegen-time depth counter for `{$dynamic}` blocks. Walking into
+        # a DynamicAttribute increments it; walking out decrements. Any
+        # ``_invoke_render`` or ``_invoke_component`` call emitted while
+        # this is > 0 gets a ``_pw_bypass_memo=True`` kwarg, so memoization
+        # is suppressed even when the wrapping block isn't traversed at
+        # render time (e.g. partial ``render_update``).
+        self._dynamic_codegen_depth: int = 0
         # Dev mode: readable ref IDs vs short hashes.
         # Defaults to checking PYWIRE_DEBUG env var at compile time.
         if dev_mode is not None:
@@ -123,6 +141,8 @@ class TemplateCodegen:
         self.has_file_inputs = False
         self._region_counter = 0
         self.region_renderers = {}
+        self.dynamic_regions = set()
+        self._region_codegen_stack = []
         self._wire_vars = set()
         self._expr_id_counter = 0
         self._wire_vars = set()
@@ -661,21 +681,25 @@ class TemplateCodegen:
         scope_id: Optional[str],
         implicit_root_source: Optional[str],
     ) -> ast.AsyncFunctionDef:
-        func_def = self._generate_function(
-            [node],
-            func_name,
-            is_async=True,
-            layout_id=layout_id,
-            known_methods=known_methods,
-            known_globals=known_globals,
-            known_imports=known_imports,
-            async_methods=async_methods,
-            component_map=component_map,
-            scope_id=scope_id,
-            implicit_root_source=implicit_root_source,
-            enable_regions=False,
-            root_region_id=region_id,
-        )
+        self._region_codegen_stack.append(region_id)
+        try:
+            func_def = self._generate_function(
+                [node],
+                func_name,
+                is_async=True,
+                layout_id=layout_id,
+                known_methods=known_methods,
+                known_globals=known_globals,
+                known_imports=known_imports,
+                async_methods=async_methods,
+                component_map=component_map,
+                scope_id=scope_id,
+                implicit_root_source=implicit_root_source,
+                enable_regions=False,
+                root_region_id=region_id,
+            )
+        finally:
+            self._region_codegen_stack.pop()
 
         if len(func_def.body) < 3:
             return func_def
@@ -1574,6 +1598,11 @@ class TemplateCodegen:
             fallback_func.args.args = []
             body.append(fallback_func)
 
+            bypass_kwargs = (
+                [ast.keyword(arg="_pw_bypass_memo", value=ast.Constant(value=True))]
+                if self._dynamic_codegen_depth > 0
+                else []
+            )
             call = ast.Call(
                 func=ast.Attribute(
                     value=ast.Name(id="self", ctx=ast.Load()),
@@ -1586,9 +1615,14 @@ class TemplateCodegen:
                     ast.Name(id=fallback_method, ctx=ast.Load()),
                     *arg_exprs,
                 ],
-                keywords=[],
+                keywords=bypass_kwargs,
             )
         else:
+            bypass_kwargs = (
+                [ast.keyword(arg="_pw_bypass_memo", value=ast.Constant(value=True))]
+                if self._dynamic_codegen_depth > 0
+                else []
+            )
             call = ast.Call(
                 func=ast.Attribute(
                     value=ast.Name(id="self", ctx=ast.Load()),
@@ -1600,7 +1634,7 @@ class TemplateCodegen:
                     ast.Constant(value=site_id),
                     *arg_exprs,
                 ],
-                keywords=[],
+                keywords=bypass_kwargs,
             )
 
         append_stmt = ast.Expr(
@@ -2352,6 +2386,8 @@ class TemplateCodegen:
             region_id = f"auth_{node.line}_{node.column}".replace("-", "_")
             method_name = f"_render_auth_{region_id}"
             self.region_renderers[region_id] = method_name
+            if self._dynamic_codegen_depth > 0:
+                self.dynamic_regions.add(region_id)
 
             aux_func = self._generate_auth_renderer(
                 method_name,
@@ -2594,6 +2630,8 @@ class TemplateCodegen:
             region_id = f"await_{node.line}_{node.column}".replace("-", "_")
             method_name = f"_render_await_{region_id}"
             self.region_renderers[region_id] = method_name
+            if self._dynamic_codegen_depth > 0:
+                self.dynamic_regions.add(region_id)
 
             # Generate the region renderer function
             real_await_children = node.children
@@ -2859,6 +2897,51 @@ class TemplateCodegen:
                 scope_id,
                 wire_vars=wire_vars,
             )
+            return
+
+        dynamic_attr = next(
+            (a for a in node.special_attributes if isinstance(a, DynamicAttribute)),
+            None,
+        )
+        if dynamic_attr:
+            # `{$dynamic}...{/dynamic}` — opt children out of memoization.
+            # Tracked at codegen time (not runtime) so the decision survives
+            # partial `render_update` cycles where the wrapping block isn't
+            # traversed but its descendants' generated code still needs to
+            # bypass the snippet/component cache.
+            #
+            # Tag the *enclosing* region (top of the codegen stack) as
+            # dynamic so it force-dirties on every render — that ensures
+            # impure expressions adjacent to the dynamic block in the same
+            # region (e.g. `<p>{counter()}</p>` siblings, or wire-free
+            # impure content inside the dynamic block) still re-execute.
+            if self._region_codegen_stack:
+                self.dynamic_regions.add(self._region_codegen_stack[-1])
+            self._dynamic_codegen_depth += 1
+            try:
+                for child in node.children:
+                    self._add_node(
+                        child,
+                        body,
+                        local_vars=local_vars,
+                        bound_var=bound_var,
+                        layout_id=layout_id,
+                        known_methods=known_methods,
+                        known_globals=known_globals,
+                        known_imports=known_imports,
+                        async_methods=async_methods,
+                        component_map=component_map,
+                        scope_id=scope_id,
+                        parts_var=parts_var,
+                        # Propagate the caller's `enable_regions` — don't
+                        # accidentally re-enable sub-region creation for
+                        # descendants that are already inside an enclosing
+                        # region's render method (where `enable_regions=False`).
+                        enable_regions=enable_regions,
+                        wire_vars=wire_vars,
+                    )
+            finally:
+                self._dynamic_codegen_depth -= 1
             return
 
         if node.tag == "slot":
@@ -3305,14 +3388,21 @@ class TemplateCodegen:
                 )
 
             # 9. Finally, render the component template (and clean up its stale children)
+            # Routed through ``self._invoke_component`` so prop-memoization
+            # and ``{$dynamic}`` opt-out apply uniformly.
+            comp_bypass_kwargs = (
+                [ast.keyword(arg="_pw_bypass_memo", value=ast.Constant(value=True))]
+                if self._dynamic_codegen_depth > 0
+                else []
+            )
             render_call = ast.Call(
                 func=ast.Attribute(
-                    value=ast.Name(id=comp_var, ctx=ast.Load()),
-                    attr="_render_and_cleanup",
+                    value=ast.Name(id="self", ctx=ast.Load()),
+                    attr="_invoke_component",
                     ctx=ast.Load(),
                 ),
-                args=[],
-                keywords=[],
+                args=[ast.Name(id=comp_var, ctx=ast.Load())],
+                keywords=comp_bypass_kwargs,
             )
 
             append_stmt = ast.Expr(
@@ -3483,6 +3573,8 @@ class TemplateCodegen:
                 region_id = self._next_region_id()
                 method_name = f"_render_region_{region_id}"
                 self.region_renderers[region_id] = method_name
+                if self._dynamic_codegen_depth > 0:
+                    self.dynamic_regions.add(region_id)
                 self.auxiliary_functions.append(
                     self._generate_region_method(
                         node,
@@ -3674,6 +3766,15 @@ class TemplateCodegen:
                 ast.Assign(
                     targets=[ast.Name(id="attrs", ctx=ast.Store())],
                     value=ast.Dict(keys=[], values=[]),
+                )
+            )
+            # normalize_attr handles class/style dict & list bindings;
+            # imported here so reactive-attr emission below can reference it.
+            body.append(
+                ast.ImportFrom(
+                    module="pywire.runtime.attrs",
+                    names=[ast.alias(name="normalize_attr", asname=None)],
+                    level=0,
                 )
             )
 
@@ -4400,12 +4501,14 @@ class TemplateCodegen:
                                                 ],
                                                 value=ast.Call(
                                                     func=ast.Name(
-                                                        id="str", ctx=ast.Load()
+                                                        id="normalize_attr",
+                                                        ctx=ast.Load(),
                                                     ),
                                                     args=[
+                                                        ast.Constant(value=attr.name),
                                                         ast.Name(
                                                             id="_r_val", ctx=ast.Load()
-                                                        )
+                                                        ),
                                                     ],
                                                     keywords=[],
                                                 ),

--- a/packages/pywire/src/pywire/core/wire.py
+++ b/packages/pywire/src/pywire/core/wire.py
@@ -62,6 +62,10 @@ class WireBase:
         self._parent = parent
         self._field = field
         self._frozen = False
+        # Per-wire write counter. Bumped on every `_notify_write`. Used
+        # by component-level memoization to invalidate only when wires
+        # this specific component reads have been written.
+        self._write_seq: int = 0
 
     def _track_read(self, field: str = "value") -> None:
         if self._frozen:
@@ -105,6 +109,10 @@ class WireBase:
             raise ReactivityError(
                 f"Cannot modify wire state inside a derived (derived fn={_TRACKING_STACK[-1].fn.__name__})"
             )
+
+        # Bump write seq so component-memo callers can detect changes to
+        # the specific wires they captured during their last render.
+        self._write_seq += 1
 
         # Notify parent if this is a proxy
         if self._parent:

--- a/packages/pywire/src/pywire/runtime/attrs.py
+++ b/packages/pywire/src/pywire/runtime/attrs.py
@@ -1,0 +1,49 @@
+"""Runtime helpers for reactive attribute normalization.
+
+Used by codegen to render `class={...}` and `style={...}` bindings whose
+runtime value may be a list, tuple, dict, or string. Other attributes
+fall through to plain `str(value)`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _normalize_class(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        return " ".join(str(k) for k, v in value.items() if v)
+    if isinstance(value, (list, tuple, set)):
+        return " ".join(str(item) for item in value if item)
+    return str(value)
+
+
+def _normalize_style(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        parts = []
+        for k, v in value.items():
+            if v is None or v is False:
+                continue
+            parts.append(f"{k}:{v}")
+        return ";".join(parts)
+    return str(value)
+
+
+def normalize_attr(name: str, value: Any) -> str:
+    """Render a reactive attribute value as a string.
+
+    Special handling:
+    - ``class``: list/tuple/set → space-joined truthy items;
+      dict → space-joined keys whose values are truthy.
+    - ``style``: dict → ``;``-joined ``k:v`` pairs (skips None/False).
+    - Anything else: ``str(value)``.
+    """
+    if name == "class":
+        return _normalize_class(value)
+    if name == "style":
+        return _normalize_style(value)
+    return str(value)

--- a/packages/pywire/src/pywire/runtime/page.py
+++ b/packages/pywire/src/pywire/runtime/page.py
@@ -255,6 +255,18 @@ class BasePage:
         self._expr_counts: Dict[str, int] = defaultdict(int)
         self._capturing_deps: bool = False
         self._captured_deps: Set[Tuple[Any, str]] = set()
+        # Counter for active dynamic-region renders. While >0, ``_render_expr``
+        # bypasses ``_static_cache`` so impure dep-free expressions
+        # (datetime.now(), counters, random) re-execute every cycle.
+        self._dynamic_render_depth: int = 0
+
+        # Component memoization (used by ``_invoke_component``). On a
+        # cache hit we return ``_pw_memo_html`` without re-rendering.
+        # Captured deps are (wire, field) → ``_write_seq`` snapshots.
+        self._pw_resolve_props: Optional[Dict[str, Any]] = None
+        self._pw_memo_props: Optional[Dict[str, Any]] = None
+        self._pw_memo_html: Optional[str] = None
+        self._pw_memo_dep_versions: Optional[Dict[Tuple[Any, str], int]] = None
 
         # Render-region (snippet) system:
         # - ``_head_buffer``: accumulator for ``{$head}...{/head}`` contributions
@@ -270,6 +282,14 @@ class BasePage:
         else:
             self._head_buffer = HeadBuffer()
         self._snippet_invocations: Dict[str, Tuple[Any, str]] = {}
+        # Monotonic counter bumped on every wire write that targets this
+        # page. Components snapshot this seq when caching their rendered
+        # HTML; on the next render, a higher seq invalidates the cache.
+        # This is broader than ``_dirty_regions`` (which only tracks wires
+        # the parent's regions read), so it correctly invalidates a parent
+        # component's cache when a wire READ inside a CHILD component is
+        # later written.
+        self._wire_write_seq: int = 0
         # Output-equality cache for the general region system. Keyed by
         # ``region_id``; value is the last rendered HTML. Used by
         # ``render_update`` to skip morphdom patches when a dirty region
@@ -498,19 +518,124 @@ class BasePage:
 
         self.attrs = fallback_attrs
 
+    async def _invoke_component(
+        self, comp: "BasePage", _pw_bypass_memo: bool = False
+    ) -> str:
+        """Render a child component with prop-memoization.
+
+        Memoizes the component's rendered HTML keyed on:
+
+        - ``comp.attrs`` (props equality)
+        - The set of wires the component read on its last render, plus
+          each wire's ``_write_seq`` snapshot at that time.
+
+        On subsequent invocations, if props compare equal AND none of the
+        previously-captured wires has been written since, the cached HTML
+        is reused. Bumping a wire that the component didn't read does
+        NOT invalidate its cache.
+
+        Inside a ``{$dynamic}`` block (codegen sets
+        ``_pw_bypass_memo=True``) the cache is bypassed entirely.
+        """
+        if _pw_bypass_memo:
+            comp._dynamic_render_depth += 1
+            try:
+                return await comp._render_and_cleanup()
+            finally:
+                comp._dynamic_render_depth -= 1
+
+        # Memo key = real props captured at ``_resolve_component`` time
+        # (real props get setattr'd onto the comp instance and don't show
+        # up in ``comp.attrs``). Fall back to ``attrs`` for components
+        # invoked outside the codegen path.
+        snap_source = getattr(comp, "_pw_resolve_props", None)
+        if snap_source is None:
+            snap_source = comp.attrs
+        try:
+            props_snapshot = dict(snap_source)
+        except Exception:
+            return await comp._render_and_cleanup()
+
+        prev_props = getattr(comp, "_pw_memo_props", None)
+        prev_html: Optional[str] = getattr(comp, "_pw_memo_html", None)
+        prev_dep_versions: Optional[Dict[Tuple[Any, str], int]] = getattr(
+            comp, "_pw_memo_dep_versions", None
+        )
+        if prev_props is not None and prev_html is not None:
+            try:
+                same_props = prev_props == props_snapshot
+            except Exception:
+                same_props = False
+            if same_props:
+                stale = False
+                if prev_dep_versions:
+                    for (wire_obj, _field), prev_seq in prev_dep_versions.items():
+                        cur_seq = getattr(wire_obj, "_write_seq", None)
+                        if cur_seq != prev_seq:
+                            stale = True
+                            break
+                if not stale:
+                    return prev_html
+
+        # Cache miss: render the child under its own render context so wire
+        # reads route to ``comp._register_wire_read`` (registering on the
+        # component's per-region dep map), not the parent's. After render,
+        # snapshot every (wire, field) the comp's regions read this cycle
+        # plus their ``_write_seq`` for next-call invalidation.
+        from pywire.core.wire import set_render_context, reset_render_context
+
+        # Drop the prior cumulative dep map so we capture a fresh, accurate
+        # set on this render — otherwise wires read on past renders but no
+        # longer touched would falsely invalidate the cache when bumped.
+        comp._region_dependencies.clear()
+        comp._wire_subscribers.clear()
+
+        token = set_render_context(comp, "_component_root")
+        try:
+            html = await comp._render_and_cleanup()
+        finally:
+            reset_render_context(token)
+
+        captured: Set[Tuple[Any, str]] = set()
+        for keys in comp._region_dependencies.values():
+            captured |= keys
+        dep_versions: Dict[Tuple[Any, str], int] = {
+            key: getattr(key[0], "_write_seq", 0) for key in captured
+        }
+
+        comp._pw_memo_props = props_snapshot  # type: ignore[attr-defined]
+        comp._pw_memo_html = html  # type: ignore[attr-defined]
+        comp._pw_memo_dep_versions = dep_versions  # type: ignore[attr-defined]
+        return html
+
     def _resolve_component(
         self, key: str, cls: type["BasePage"], **kwargs: Any
     ) -> "BasePage":
         self._active_component_keys.add(key)
 
+        # Snapshot non-framework, non-slot props for memoization. Real props
+        # (e.g. ``initial=a.value``) become instance attrs via
+        # ``_update_props`` rather than landing in ``comp.attrs``, so
+        # ``_invoke_component`` cannot recover them from the comp instance.
+        # Capture them here at the call site instead. Slot ``Snippet``s are
+        # excluded — they are fresh closures each render and would always
+        # invalidate the cache.
+        memo_props = {
+            k: v
+            for k, v in kwargs.items()
+            if not cls._is_framework_prop_key(k) and not isinstance(v, Snippet)
+        }
+
         component = self._components.get(key)
         if component is not None and isinstance(component, cls):
             component._update_props(kwargs)
+            component._pw_resolve_props = memo_props  # type: ignore[attr-defined]
             return component
 
         kwargs["_parent_page"] = self
         kwargs["_component_key"] = key
         instance = cls(**kwargs)
+        instance._pw_resolve_props = memo_props  # type: ignore[attr-defined]
 
         snapshot = self._component_state_snapshots.pop(key, None)
         if snapshot:
@@ -705,6 +830,7 @@ class BasePage:
         snippet: Optional[Snippet],
         site_id: str,
         *args: Any,
+        _pw_bypass_memo: bool = False,
     ) -> str:
         """Render a snippet at invocation site ``site_id`` with ``args``.
 
@@ -715,6 +841,11 @@ class BasePage:
         that tracks wire reads at ``site_id``, caches the output, and
         returns it.
 
+        ``_pw_bypass_memo`` is set by codegen for invocations that live
+        inside a ``{$dynamic}`` block, including descendants — guarantees
+        the bypass survives partial ``render_update`` cycles where the
+        wrapping block isn't traversed.
+
         Raises ``TypeError`` if ``snippet`` is ``None`` — a required
         snippet prop was not provided. For optional snippets with a
         fallback, use :meth:`_invoke_render_with_fallback`.
@@ -722,7 +853,9 @@ class BasePage:
         if snippet is None:
             raise TypeError(_missing_snippet_message(site_id, self.__class__.__name__))
         try:
-            return await self._invoke_snippet_inner(snippet, site_id, args)
+            return await self._invoke_snippet_inner(
+                snippet, site_id, args, bypass_memo=_pw_bypass_memo
+            )
         except TypeError as e:
             raise _rewrite_snippet_typeerror(e, site_id) from e
 
@@ -732,6 +865,7 @@ class BasePage:
         site_id: str,
         fallback: Callable[..., Awaitable[str]],
         *args: Any,
+        _pw_bypass_memo: bool = False,
     ) -> str:
         """Render ``snippet`` at ``site_id``; on ``None`` run ``fallback``.
 
@@ -742,11 +876,33 @@ class BasePage:
             # Fallback runs under the same site_id so its wire reads
             # invalidate this site if they change.
             return await self._invoke_region(site_id, fallback, args=())
-        return await self._invoke_snippet_inner(snippet, site_id, args)
+        return await self._invoke_snippet_inner(
+            snippet, site_id, args, bypass_memo=_pw_bypass_memo
+        )
 
     async def _invoke_snippet_inner(
-        self, snippet: Snippet, site_id: str, args: Tuple[Any, ...]
+        self,
+        snippet: Snippet,
+        site_id: str,
+        args: Tuple[Any, ...],
+        bypass_memo: bool = False,
     ) -> str:
+        # `{$dynamic}` block at codegen time: bypass memoization entirely.
+        # Drop any prior cache entry so a later render outside the dynamic
+        # block can't serve stale output, and run the body fresh. Also bump
+        # `_dynamic_render_depth` so impure dep-free expressions inside the
+        # snippet body (e.g. side-effect counters) bypass `_static_cache`.
+        if bypass_memo:
+            self._snippet_invocations.pop(site_id, None)
+            self._dirty_regions.discard(site_id)
+            self._dynamic_render_depth += 1
+            try:
+                html = await self._invoke_region(site_id, snippet.render, args=args)
+            finally:
+                self._dynamic_render_depth -= 1
+            self._region_output_cache[site_id] = html
+            return html
+
         # If a wire write marked this site dirty since the last render,
         # drop the cache entry before checking for a hit.
         if site_id in self._dirty_regions:
@@ -1043,6 +1199,7 @@ class BasePage:
                     pass
 
                 sibling_paths_raw = getattr(self, "__sibling_paths__", []) or []
+                page_no_interactive = bool(getattr(self, "__no_interactive__", False))
                 meta = {
                     "sibling_paths": [_prefix(p) for p in sibling_paths_raw],
                     "all_paths": [_prefix(p) for p in all_wire_paths],
@@ -1053,6 +1210,9 @@ class BasePage:
                     "reconnect_max_attempts": reconnect_max_attempts,
                     "reconnect_overlay": reconnect_overlay_enabled,
                     "interactive": interactive_mode,
+                    # Per-page !no_interactive: WebSocket stays connected,
+                    # but the client skips event/wire wiring on this page.
+                    "page_interactive": not page_no_interactive,
                     "dev_reload_url": dev_reload_url,
                 }
                 import json
@@ -1177,8 +1337,22 @@ class BasePage:
         self._expr_counts[static_id] += 1
         instance_id = f"{static_id}:{count}"
 
+        # Inside a `{$dynamic}` region, never serve or store a cached value —
+        # impure dep-free expressions (datetime.now(), counters, random)
+        # must re-execute every cycle. Detect via render-context region_id
+        # so this works for both full and partial render paths.
+        bypass = self._dynamic_render_depth > 0
+        if not bypass:
+            dyn = getattr(self, "__dynamic_regions__", None)
+            if dyn:
+                from pywire.core.wire import _render_context
+
+                ctx = _render_context.get()
+                if ctx is not None and ctx[1] in dyn:
+                    bypass = True
+
         # If cached, return it
-        if instance_id in self._static_cache:
+        if not bypass and instance_id in self._static_cache:
             return self._static_cache[instance_id]
 
         # Otherwise compute and potentially cache
@@ -1196,8 +1370,9 @@ class BasePage:
             self._capturing_deps = prev_capturing
             self._captured_deps = prev_captured
 
-        # If no wire dependencies, cache it
-        if not deps:
+        # If no wire dependencies, cache it (unless we're inside a
+        # `{$dynamic}` region where caching is suppressed).
+        if not deps and not bypass:
             self._static_cache[instance_id] = result
 
         return result
@@ -1215,6 +1390,13 @@ class BasePage:
             self._captured_deps.add(key)
 
     def _invalidate_wire(self, wire_obj: Any, field: str) -> None:
+        # Bump the global wire-write counter. Components snapshot this on
+        # render and use it to invalidate their cache when ANY wire write
+        # happens, even one that doesn't go through region tracking
+        # (covers wires read inside child components whose region context
+        # belongs to the child, not the parent).
+        self._wire_write_seq += 1
+
         regions = set()
         key = (wire_obj, field)
         if key in self._wire_subscribers:
@@ -1274,6 +1456,21 @@ class BasePage:
             _request_ctx.reset(token)
 
     async def render_update(self, init: bool = False) -> Dict[str, Any]:
+        # `{$dynamic}` regions force-dirty on every update so the bypass kwarg
+        # on inner _invoke_render/_invoke_component calls actually executes.
+        dynamic_regions = getattr(self, "__dynamic_regions__", None)
+        if dynamic_regions:
+            self._dirty_regions.update(dynamic_regions)
+
+        # Send fresh page_interactive on every SPA-nav response so the client
+        # re-evaluates whether to wire up event handlers for this page.
+        # Initial full-page render emits this in the `_pywire_spa_meta`
+        # script tag; SPA-nav responses don't include that tag, so the
+        # client picks the value off the response payload instead.
+        update_meta = {
+            "page_interactive": not bool(getattr(self, "__no_interactive__", False)),
+        }
+
         # Optimization: If we have region renderers (compiled page) and this is a partial update (init=False),
         # check if we really need to update anything.
         if hasattr(self, "__region_renderers__") and (self._dirty_regions or not init):
@@ -1286,6 +1483,7 @@ class BasePage:
                     commands = (commands or []) + cookie_cmds
                 if commands:
                     result["commands"] = commands
+                result["meta"] = update_meta
                 return result
 
             logger.debug(f"render_update: dirty_regions={self._dirty_regions}")
@@ -1311,7 +1509,12 @@ class BasePage:
                     if not renderer:
                         continue
 
+                    is_dynamic = (
+                        dynamic_regions is not None and region_id in dynamic_regions
+                    )
                     token = set_render_context(self, region_id)
+                    if is_dynamic:
+                        self._dynamic_render_depth += 1
                     try:
                         if inspect.iscoroutinefunction(renderer):
                             region_html = await renderer()
@@ -1327,6 +1530,8 @@ class BasePage:
                         has_root_dirty = True
                         break
                     finally:
+                        if is_dynamic:
+                            self._dynamic_render_depth -= 1
                         reset_render_context(token)
 
                     stripped_html = region_html.lstrip()
@@ -1358,7 +1563,7 @@ class BasePage:
                     self._dirty_regions.clear()
 
                     # If we successfully generated partial updates, return them
-                    result = {"type": "regions", "regions": updates}
+                    result: Dict[str, Any] = {"type": "regions", "regions": updates}
                     logger.debug("RENDER-UPDATE-REGIONS: %s", updates)
 
                     # 2. Collect commands from all refs (recursively)
@@ -1369,6 +1574,7 @@ class BasePage:
                     if commands:
                         result["commands"] = commands
 
+                    result["meta"] = update_meta
                     return result
 
         # Flush cookie commands before render() (which would apply them to the
@@ -1406,6 +1612,7 @@ class BasePage:
             commands = (commands or []) + cookie_cmds
         if commands:
             result["commands"] = commands
+        result["meta"] = update_meta
         return result
 
     async def push_state(self) -> None:

--- a/packages/pywire/src/pywire/runtime/websocket.py
+++ b/packages/pywire/src/pywire/runtime/websocket.py
@@ -666,21 +666,37 @@ class WebSocketHandler:
                 await websocket.send_bytes(msgpack.packb(payload))
                 return
 
-            # 5. Success (200) — send body HTML and set up local page instance
+            # 5. Success (200) — send body HTML and set up local page instance.
+            # Resolve the new page first so we can both attach meta to the
+            # response payload AND set it up as the connection's active
+            # page below (single resolve_page call, not two).
+            old_page = self.connection_pages.get(websocket)
+            result = resolve_page(
+                self.app.router, path, base_scope=dict(websocket.scope)
+            )
+
             html = response.body.decode("utf-8")
             payload: Dict[str, Any] = {"type": "update", "html": html}
             if cookie_commands:
                 payload["commands"] = cookie_commands
+
+            # Include per-page meta so the client can re-evaluate
+            # `!no_interactive` after SPA nav. The internal dispatch
+            # rendered with init=False so the response body has no
+            # `_pywire_spa_meta` script tag — without this, the client
+            # carries the previous page's `pageInteractive` value.
+            if result:
+                payload["meta"] = {
+                    "page_interactive": not bool(
+                        getattr(result[0], "__no_interactive__", False)
+                    ),
+                }
+
             await websocket.send_bytes(msgpack.packb(payload))
 
-            # 6. Create local page instance for WS state management
-            #    (The internal dispatch already rendered the page — this instance
-            #    is for handling subsequent events on the new page.)
-            old_page = self.connection_pages.get(websocket)
-
-            result = resolve_page(
-                self.app.router, path, base_scope=dict(websocket.scope)
-            )
+            # 6. Continue setting up the local page instance for WS state
+            #    management (The internal dispatch already rendered the page
+            #    — this instance is for handling subsequent events on the new page.)
             if result:
                 new_page, _params, _variant_name = result
 

--- a/packages/pywire/tests/test_attr_normalize.py
+++ b/packages/pywire/tests/test_attr_normalize.py
@@ -1,0 +1,127 @@
+"""Tests for class/style dict & list attribute binding (#152)."""
+
+from __future__ import annotations
+
+import ast as py_ast
+from typing import Any, Type
+
+import pytest
+from starlette.requests import Request
+
+from pywire_parser.parser import PyWireParser
+from pywire.compiler.codegen.generator import CodeGenerator
+from pywire.runtime.attrs import normalize_attr
+from pywire.runtime.page import BasePage
+
+
+def _compile_source(source: str, module_name: str) -> Type[BasePage]:
+    parsed = PyWireParser().parse(source, f"/virtual/{module_name}.wire")
+    gen = CodeGenerator()
+    module_ast = gen.generate(parsed)
+    py_ast.fix_missing_locations(module_ast)
+    code = compile(module_ast, filename=f"<{module_name}>", mode="exec")
+    ns: dict[str, Any] = {"__name__": module_name}
+    exec(code, ns)
+    for name in reversed(list(ns.keys())):
+        v = ns[name]
+        if isinstance(v, type) and name.endswith("Page") and name != "BasePage":
+            return v
+    raise RuntimeError("No Page class was generated")
+
+
+def _make_request() -> Request:
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        "raw_path": b"/",
+        "query_string": b"",
+        "headers": [],
+        "client": ("127.0.0.1", 0),
+        "server": ("testserver", 80),
+        "scheme": "http",
+        "root_path": "",
+        "http_version": "1.1",
+    }
+    return Request(scope)
+
+
+def test_normalize_class_list():
+    assert normalize_attr("class", ["a", "b", "c"]) == "a b c"
+
+
+def test_normalize_class_tuple_skips_falsy():
+    assert normalize_attr("class", ("a", "", "b", None, "c")) == "a b c"
+
+
+def test_normalize_class_dict_truthy_keys():
+    assert normalize_attr("class", {"a": True, "b": False, "c": 1, "d": 0}) == "a c"
+
+
+def test_normalize_class_str_passthrough():
+    assert normalize_attr("class", "btn primary") == "btn primary"
+
+
+def test_normalize_style_dict():
+    assert normalize_attr("style", {"color": "red", "font-size": "12px"}) == (
+        "color:red;font-size:12px"
+    )
+
+
+def test_normalize_style_dict_skips_none_false():
+    assert (
+        normalize_attr("style", {"color": "red", "display": None, "border": False})
+        == "color:red"
+    )
+
+
+def test_normalize_style_str_passthrough():
+    assert normalize_attr("style", "color: red") == "color: red"
+
+
+def test_normalize_other_attr_str():
+    assert normalize_attr("id", 42) == "42"
+    assert normalize_attr("data-x", "value") == "value"
+
+
+@pytest.mark.asyncio
+async def test_codegen_class_list_binding():
+    """`<div class={['a', 'b']}>` renders with class='a b'."""
+    src = """---
+classes = ["a", "b"]
+---
+<div class={classes}></div>
+"""
+    cls = _compile_source(src, "class_list")
+    page = cls(_make_request(), {}, {})
+    html = await page._render_template()
+    assert 'class="a b"' in html
+
+
+@pytest.mark.asyncio
+async def test_codegen_class_dict_binding():
+    """`<div class={{'a': True, 'b': False}}>` renders with class='a'."""
+    src = """---
+state = {"a": True, "b": False, "c": 1}
+---
+<div class={state}></div>
+"""
+    cls = _compile_source(src, "class_dict")
+    page = cls(_make_request(), {}, {})
+    html = await page._render_template()
+    assert 'class="a c"' in html
+
+
+@pytest.mark.asyncio
+async def test_codegen_style_dict_binding():
+    """`<div style={{'color': 'red'}}>` renders style as `;`-joined pairs."""
+    src = """---
+sty = {"color": "red", "font-size": "12px"}
+---
+<div style={sty}></div>
+"""
+    cls = _compile_source(src, "style_dict")
+    page = cls(_make_request(), {}, {})
+    html = await page._render_template()
+    assert "color:red" in html
+    assert "font-size:12px" in html

--- a/packages/pywire/tests/test_auth_block.py
+++ b/packages/pywire/tests/test_auth_block.py
@@ -53,9 +53,7 @@ def _engine_with_admin_policy() -> PolicyEngine:
 
 
 async def _render_twice(cls, user: ClaimsPrincipal, engine: PolicyEngine):
-    ctx = AuthContext(
-        principal=user, engine=engine, channel=MemoryAuthChannel()
-    )
+    ctx = AuthContext(principal=user, engine=engine, channel=MemoryAuthChannel())
     tok = set_auth_context(ctx)
     try:
         page = cls(request=None, params={}, query={}, path={}, url=None)
@@ -78,7 +76,9 @@ def test_parser_emits_auth_attribute_with_policy():
     from pywire_parser import PyWireParser
     from pywire_parser.ast_nodes import AuthAttribute
 
-    result = PyWireParser().parse('---\n---\n{$auth policy="AdminOnly"}<p>x</p>{/auth}\n')
+    result = PyWireParser().parse(
+        '---\n---\n{$auth policy="AdminOnly"}<p>x</p>{/auth}\n'
+    )
     attrs = [
         a
         for n in result.template
@@ -178,9 +178,7 @@ async def test_policy_denied_renders_denied_body():
 
 @pytest.mark.asyncio
 async def test_no_else_branch_hides_denied_body():
-    cls = _compile(
-        '<div>{$auth policy="AdminOnly"}<p>admin</p>{/auth}</div>'
-    )
+    cls = _compile('<div>{$auth policy="AdminOnly"}<p>admin</p>{/auth}</div>')
     _, resolved = await _render_twice(
         cls, _admin_principal(False), _engine_with_admin_policy()
     )
@@ -192,14 +190,10 @@ async def test_claim_check_matches_value():
     cls = _compile(
         '<div>{$auth claims=[("role","admin")]}<p>a</p>{$else}<p>d</p>{/auth}</div>'
     )
-    _, resolved = await _render_twice(
-        cls, _admin_principal(True), PolicyEngine()
-    )
+    _, resolved = await _render_twice(cls, _admin_principal(True), PolicyEngine())
     assert "<p>a</p>" in resolved
 
-    _, resolved = await _render_twice(
-        cls, _admin_principal(False), PolicyEngine()
-    )
+    _, resolved = await _render_twice(cls, _admin_principal(False), PolicyEngine())
     assert "<p>d</p>" in resolved
 
 
@@ -240,7 +234,7 @@ async def test_authorizing_body_shows_on_first_render_before_task_completes():
 
 @pytest.mark.asyncio
 async def test_anonymous_with_no_args_denies():
-    cls = _compile('<div>{$auth}<p>in</p>{$else}<p>out</p>{/auth}</div>')
+    cls = _compile("<div>{$auth}<p>in</p>{$else}<p>out</p>{/auth}</div>")
     anon = ClaimsPrincipal(is_authenticated=False)
     _, resolved = await _render_twice(cls, anon, PolicyEngine())
     assert "<p>out</p>" in resolved
@@ -251,9 +245,7 @@ async def test_unknown_policy_fails_closed():
     cls = _compile(
         '<div>{$auth policy="DoesNotExist"}<p>in</p>{$else}<p>out</p>{/auth}</div>'
     )
-    _, resolved = await _render_twice(
-        cls, _admin_principal(True), PolicyEngine()
-    )
+    _, resolved = await _render_twice(cls, _admin_principal(True), PolicyEngine())
     assert "<p>out</p>" in resolved
 
 
@@ -262,7 +254,7 @@ async def test_nested_inside_for_loop():
     """One {$auth} per iteration evaluates independently."""
     cls = _compile(
         "<ul>"
-        '{$for x in items}'
+        "{$for x in items}"
         '<li>{$auth claims=[("role","admin")]}[admin]{$else}[user]{/auth}{x}</li>'
         "{/for}"
         "</ul>"

--- a/packages/pywire/tests/test_dynamic_memoization.py
+++ b/packages/pywire/tests/test_dynamic_memoization.py
@@ -1,0 +1,680 @@
+"""End-to-end tests for ``{$dynamic}`` memoization escape.
+
+Verifies that:
+
+- Snippet invocations are memoized across renders by default
+  (``BasePage._invoke_snippet_inner`` caches by site_id + arg equality).
+- A ``{$dynamic} ... {/dynamic}`` wrapper bypasses that cache for any
+  snippet/render-region invocation in its subtree, even with identical
+  args.
+- The bypass is scoped: regions outside the wrapper continue to memoize.
+- Nested ``{$dynamic}`` blocks behave (idempotent — depth-counted).
+"""
+
+from __future__ import annotations
+
+import ast as py_ast
+from typing import Any, Type
+
+import pytest
+from starlette.requests import Request
+
+from pywire_parser.parser import PyWireParser
+from pywire.compiler.codegen.generator import CodeGenerator
+from pywire.runtime.page import BasePage
+
+
+def _compile_source(source: str, module_name: str) -> Type[BasePage]:
+    parsed = PyWireParser().parse(source, f"/virtual/{module_name}.wire")
+    gen = CodeGenerator()
+    module_ast = gen.generate(parsed)
+    py_ast.fix_missing_locations(module_ast)
+    code = compile(module_ast, filename=f"<{module_name}>", mode="exec")
+    ns: dict[str, Any] = {"__name__": module_name}
+    exec(code, ns)
+    for name in reversed(list(ns.keys())):
+        v = ns[name]
+        if isinstance(v, type) and name.endswith("Page") and name != "BasePage":
+            return v
+    raise RuntimeError("No Page class was generated")
+
+
+def _make_request() -> Request:
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        "raw_path": b"/",
+        "query_string": b"",
+        "headers": [],
+        "client": ("127.0.0.1", 0),
+        "server": ("testserver", 80),
+        "scheme": "http",
+        "root_path": "",
+        "http_version": "1.1",
+    }
+    return Request(scope)
+
+
+@pytest.mark.asyncio
+async def test_snippet_memoization_baseline_caches_identical_args():
+    """Same site_id + same args → second render hits cache."""
+    src = """---
+---
+{$snippet row(x)}
+<li>{x}</li>
+{/snippet}
+<ul>
+{$render row(1)}
+</ul>
+"""
+    cls = _compile_source(src, "memo_baseline")
+    page = cls(_make_request(), {}, {})
+
+    h1 = await page._render_template()
+    assert "<li>1</li>" in h1
+
+    # The site_id assigned at the {$render} call should be in the
+    # invocation cache after first render.
+    assert len(page._snippet_invocations) == 1
+    site_id, (cached_args, cached_html) = next(iter(page._snippet_invocations.items()))
+    assert "<li>1</li>" in cached_html
+
+
+@pytest.mark.asyncio
+async def test_dynamic_block_skips_snippet_cache():
+    """A {$dynamic} wrapper around a {$render} bypasses the per-site cache."""
+    src = """---
+---
+{$snippet row(x)}
+<li>{x}</li>
+{/snippet}
+{$dynamic}
+<ul>
+{$render row(1)}
+</ul>
+{/dynamic}
+"""
+    cls = _compile_source(src, "dynamic_skip")
+    page = cls(_make_request(), {}, {})
+
+    await page._render_template()
+    # Inside {$dynamic} the cache is dropped after each invocation, so
+    # the per-site cache should be empty.
+    assert page._snippet_invocations == {}
+
+
+@pytest.mark.asyncio
+async def test_dynamic_does_not_leak_to_sibling_renders():
+    """Sibling {$render} calls outside {$dynamic} continue to memoize."""
+    src = """---
+---
+{$snippet row(x)}
+<li>{x}</li>
+{/snippet}
+<section>
+{$dynamic}
+{$render row(1)}
+{/dynamic}
+{$render row(2)}
+</section>
+"""
+    cls = _compile_source(src, "dynamic_resets")
+    page = cls(_make_request(), {}, {})
+
+    await page._render_template()
+    # The dynamic-wrapped invocation is NOT cached. The trailing
+    # invocation outside the block IS cached. Net cache size: 1.
+    assert len(page._snippet_invocations) == 1
+
+
+@pytest.mark.asyncio
+async def test_dynamic_nested_blocks_render_all_content():
+    """Nested {$dynamic} blocks all render their content correctly."""
+    src = """---
+---
+{$dynamic}
+<p>outer</p>
+{$dynamic}
+<p>inner</p>
+{/dynamic}
+<p>after-inner</p>
+{/dynamic}
+"""
+    cls = _compile_source(src, "dynamic_nested")
+    page = cls(_make_request(), {}, {})
+
+    html = await page._render_template()
+    assert "<p>outer</p>" in html
+    assert "<p>inner</p>" in html
+    assert "<p>after-inner</p>" in html
+
+
+@pytest.mark.asyncio
+async def test_dynamic_block_with_no_children_is_noop():
+    """Empty {$dynamic} block compiles and doesn't blow up."""
+    src = """---
+---
+<p>before</p>
+{$dynamic}
+{/dynamic}
+<p>after</p>
+"""
+    cls = _compile_source(src, "dynamic_empty")
+    page = cls(_make_request(), {}, {})
+
+    html = await page._render_template()
+    assert "<p>before</p>" in html
+    assert "<p>after</p>" in html
+
+
+@pytest.mark.asyncio
+async def test_wire_write_seq_increments_on_invalidate():
+    """`_invalidate_wire` bumps the global wire-write counter."""
+    src = """---
+---
+<p>x</p>
+"""
+    cls = _compile_source(src, "wseq_basic")
+    page = cls(_make_request(), {}, {})
+    assert page._wire_write_seq == 0
+
+    # Simulate a wire write reaching this page.
+    page._invalidate_wire(object(), "field")
+    assert page._wire_write_seq == 1
+
+    page._invalidate_wire(object(), "field")
+    assert page._wire_write_seq == 2
+
+
+@pytest.mark.asyncio
+async def test_invoke_component_caches_when_props_and_wires_unchanged():
+    """Component HTML cached when props unchanged + captured wires unchanged."""
+    from pywire import wire
+    from pywire.core.wire import set_render_context, reset_render_context
+
+    src = """---
+---
+<p>parent</p>
+"""
+    cls = _compile_source(src, "comp_memo")
+    page = cls(_make_request(), {}, {})
+
+    used_wire = wire(0)
+
+    class _ChildPage(BasePage):
+        async def _render_and_cleanup(self) -> str:  # type: ignore[override]
+            self._render_calls = getattr(self, "_render_calls", 0) + 1
+            # Real components set render context inside their region
+            # methods; mimic that so the wire read registers as a dep
+            # on the component (which is what _invoke_component captures).
+            tok = set_render_context(self, "child_region")
+            try:
+                _ = used_wire.value
+            finally:
+                reset_render_context(tok)
+            return "<span>child</span>"
+
+    child = _ChildPage(_make_request(), {}, {})
+    child.attrs = {"x": 1}
+
+    h1 = await page._invoke_component(child)
+    h2 = await page._invoke_component(child)
+    assert h1 == h2 == "<span>child</span>"
+    assert child._render_calls == 1  # second invocation hit the cache
+
+    # Mutate the captured wire → cache invalidates on next call.
+    used_wire.value = 1
+    h3 = await page._invoke_component(child)
+    assert h3 == "<span>child</span>"
+    assert child._render_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_invoke_component_ignores_unread_wire_changes():
+    """Bumping a wire the component never read does NOT invalidate its cache."""
+    from pywire import wire
+    from pywire.core.wire import set_render_context, reset_render_context
+
+    src = """---
+---
+<p>parent</p>
+"""
+    cls = _compile_source(src, "comp_unread_wire")
+    page = cls(_make_request(), {}, {})
+
+    read_wire = wire(0)
+    other_wire = wire(0)
+
+    class _ChildPage(BasePage):
+        async def _render_and_cleanup(self) -> str:  # type: ignore[override]
+            self._render_calls = getattr(self, "_render_calls", 0) + 1
+            tok = set_render_context(self, "child_region")
+            try:
+                _ = read_wire.value
+            finally:
+                reset_render_context(tok)
+            return "<span>c</span>"
+
+    child = _ChildPage(_make_request(), {}, {})
+    child.attrs = {"x": 1}
+
+    await page._invoke_component(child)
+    other_wire.value = 99  # bump a wire the child didn't read
+    await page._invoke_component(child)
+    assert child._render_calls == 1  # cache hit — other_wire is irrelevant
+
+    read_wire.value = 1  # bump the wire the child DID read
+    await page._invoke_component(child)
+    assert child._render_calls == 2  # cache miss — re-rendered
+
+
+@pytest.mark.asyncio
+async def test_invoke_component_invalidates_on_prop_change():
+    src = """---
+---
+<p>p</p>
+"""
+    cls = _compile_source(src, "comp_props_change")
+    page = cls(_make_request(), {}, {})
+
+    class _ChildPage(BasePage):
+        async def _render_and_cleanup(self) -> str:  # type: ignore[override]
+            self._render_calls = getattr(self, "_render_calls", 0) + 1
+            return f"<span>{self.attrs.get('x')}</span>"
+
+    child = _ChildPage(_make_request(), {}, {})
+    child.attrs = {"x": 1}
+    await page._invoke_component(child)
+    child.attrs = {"x": 2}
+    out = await page._invoke_component(child)
+    assert out == "<span>2</span>"
+    assert child._render_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_codegen_emits_bypass_kwarg_inside_dynamic_block():
+    """Generated code includes `_pw_bypass_memo=True` on _invoke_render
+    calls within a {$dynamic} block — the decision is baked at codegen
+    time so it survives partial render_update cycles."""
+    src = """---
+---
+{$snippet row(x)}
+<li>{x}</li>
+{/snippet}
+<ul>
+{$render row(1)}
+</ul>
+{$dynamic}
+<ul>
+{$render row(2)}
+</ul>
+{/dynamic}
+"""
+    parsed = PyWireParser().parse(src, "/virtual/codegen_check.wire")
+    gen = CodeGenerator()
+    module_ast = gen.generate(parsed)
+    py_ast.fix_missing_locations(module_ast)
+    src_out = py_ast.unparse(module_ast)
+    # The plain `{$render row(1)}` should NOT carry the bypass kwarg…
+    assert "_pw_bypass_memo=True" in src_out
+    # …and the bypass should appear at least once (the dynamic-wrapped call).
+    occurrences = src_out.count("_pw_bypass_memo=True")
+    invocations = src_out.count("self._invoke_render")
+    assert invocations >= 2
+    assert occurrences == 1, (
+        f"expected exactly one bypass occurrence (the dynamic-wrapped render); "
+        f"got {occurrences} across {invocations} invocations"
+    )
+
+
+@pytest.mark.asyncio
+async def test_codegen_emits_dynamic_regions_class_attr():
+    """Regions emitted under `{$dynamic}` get tagged in `__dynamic_regions__`
+    so runtime can force-dirty them every update."""
+    src = """---
+from pywire import wire
+x = wire(0)
+---
+<p>plain {x}</p>
+{$dynamic}
+<p>dynamic {x}</p>
+{/dynamic}
+"""
+    parsed = PyWireParser().parse(src, "/virtual/dyn_regions.wire")
+    gen = CodeGenerator()
+    module_ast = gen.generate(parsed)
+    py_ast.fix_missing_locations(module_ast)
+    src_out = py_ast.unparse(module_ast)
+    assert "__dynamic_regions__" in src_out, (
+        "codegen should emit __dynamic_regions__ when a {$dynamic} block "
+        "wraps a region; got:\n" + src_out
+    )
+
+
+@pytest.mark.asyncio
+async def test_dynamic_region_force_dirty_in_render_update():
+    """`__dynamic_regions__` are unioned into `_dirty_regions` at the top
+    of `render_update` so the bypass kwarg on inner _invoke_render calls
+    actually executes every cycle."""
+    src = """---
+---
+<p>plain</p>
+"""
+    cls = _compile_source(src, "dyn_force_dirty")
+    page = cls(_make_request(), {}, {})
+
+    page.__class__.__dynamic_regions__ = frozenset({"r_dummy"})  # type: ignore[attr-defined]
+    page.__class__.__region_renderers__ = {"r_dummy": "_render_region_dummy"}  # type: ignore[attr-defined]
+
+    calls = {"n": 0}
+
+    async def _render_region_dummy() -> str:
+        calls["n"] += 1
+        return "<p>dyn</p>"
+
+    page._render_region_dummy = _render_region_dummy  # type: ignore[attr-defined]
+
+    # First render — region runs.
+    await page.render_update(init=False)
+    # Second render — no wire bumped, no dirty regions, but dynamic region
+    # was force-dirtied → renderer ran again.
+    await page.render_update(init=False)
+    assert calls["n"] == 2
+
+
+@pytest.mark.asyncio
+async def test_component_memo_isolated_per_wire():
+    """Two child components reading distinct wires — bumping one wire
+    invalidates exactly one cache."""
+    from pywire import wire
+    from pywire.core.wire import set_render_context, reset_render_context
+
+    src = """---
+---
+<p>p</p>
+"""
+    cls = _compile_source(src, "comp_isolated")
+    page = cls(_make_request(), {}, {})
+
+    wire_a = wire(0)
+    wire_b = wire(0)
+
+    class _CardA(BasePage):
+        async def _render_and_cleanup(self) -> str:  # type: ignore[override]
+            self._render_calls = getattr(self, "_render_calls", 0) + 1
+            tok = set_render_context(self, "r")
+            try:
+                _ = wire_a.value
+            finally:
+                reset_render_context(tok)
+            return "A"
+
+    class _CardB(BasePage):
+        async def _render_and_cleanup(self) -> str:  # type: ignore[override]
+            self._render_calls = getattr(self, "_render_calls", 0) + 1
+            tok = set_render_context(self, "r")
+            try:
+                _ = wire_b.value
+            finally:
+                reset_render_context(tok)
+            return "B"
+
+    a = _CardA(_make_request(), {}, {})
+    b = _CardB(_make_request(), {}, {})
+    a.attrs = {}
+    b.attrs = {}
+
+    await page._invoke_component(a)
+    await page._invoke_component(b)
+    assert a._render_calls == 1
+    assert b._render_calls == 1
+
+    wire_a.value = 1  # bump A's wire only
+    await page._invoke_component(a)
+    await page._invoke_component(b)
+    assert a._render_calls == 2  # invalidated
+    assert b._render_calls == 1  # unchanged
+
+    wire_b.value = 1  # bump B's wire only
+    await page._invoke_component(a)
+    await page._invoke_component(b)
+    assert a._render_calls == 2  # unchanged
+    assert b._render_calls == 2  # invalidated
+
+
+@pytest.mark.asyncio
+async def test_component_memo_invalidates_on_prop_change():
+    """Memoization key includes real props captured at
+    ``_resolve_component`` time. Real props get setattr'd onto the comp
+    instance and don't appear in ``comp.attrs`` — the memo key must
+    still detect them."""
+
+    src = """---
+---
+<p>p</p>
+"""
+    cls = _compile_source(src, "comp_prop_memo")
+    page = cls(_make_request(), {}, {})
+
+    class _Card(BasePage):
+        initial: int = 0  # declared prop → setattr path, NOT comp.attrs
+
+        async def _render_and_cleanup(self) -> str:  # type: ignore[override]
+            self._render_calls = getattr(self, "_render_calls", 0) + 1
+            return f"<div>{self.initial}</div>"
+
+    # Pre-instantiate the component so _resolve_component takes the
+    # existing-instance path (avoids needing to thread request/params/query
+    # through cls(**kwargs) here).
+    comp = _Card(_make_request(), {}, {})
+    comp.attrs = {}
+    page._components["card"] = comp
+
+    # Simulate codegen: _resolve_component captures memo props, then
+    # _invoke_component reads them back.
+    page._resolve_component("card", _Card, initial=0)
+    await page._invoke_component(comp)
+    assert comp._render_calls == 1
+
+    # Same props → cache hit, body does not re-run.
+    page._resolve_component("card", _Card, initial=0)
+    await page._invoke_component(comp)
+    assert comp._render_calls == 1
+
+    # Prop changes → cache miss, body re-runs.
+    page._resolve_component("card", _Card, initial=1)
+    await page._invoke_component(comp)
+    assert comp._render_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_render_update_emits_page_interactive_meta():
+    """Every render_update response carries `meta.page_interactive` so
+    the client can re-evaluate the !no_interactive flag on SPA nav."""
+    src = """---
+---
+<p>p</p>
+"""
+    cls = _compile_source(src, "meta_interactive")
+    page = cls(_make_request(), {}, {})
+
+    result = await page.render_update(init=False)
+    assert "meta" in result
+    assert result["meta"].get("page_interactive") is True
+
+    # Flip the class flag — meta should track it.
+    page.__class__.__no_interactive__ = True  # type: ignore[attr-defined]
+    try:
+        result2 = await page.render_update(init=False)
+        assert result2["meta"].get("page_interactive") is False
+    finally:
+        del page.__class__.__no_interactive__
+
+
+@pytest.mark.asyncio
+async def test_dynamic_region_bypasses_static_expr_cache():
+    """Impure dep-free expressions (counter()/datetime.now()) inside a
+    `{$dynamic}` region must re-execute every render. `_render_expr`
+    caches dep-free results in `_static_cache` by default; the dynamic
+    region must bypass that cache."""
+    src = """---
+_count = {"n": 0}
+
+def tick() -> str:
+    _count["n"] += 1
+    return ""
+
+def n() -> int:
+    return _count["n"]
+---
+{$dynamic}
+<p>{tick()}n={n()}</p>
+{/dynamic}
+"""
+    cls = _compile_source(src, "dyn_static_bypass")
+    page = cls(_make_request(), {}, {})
+
+    # First full render — tick fires (n=1).
+    h1 = await page._render_template()
+    assert "n=1" in h1
+
+    # Force-dirty the dynamic region and re-run partial update. tick
+    # MUST fire again — counter advances.
+    page._expr_counts.clear()
+    h2 = await page._render_template()
+    assert "n=2" in h2, f"static cache leaked into dynamic region; got {h2!r}"
+
+
+@pytest.mark.asyncio
+async def test_dynamic_block_does_not_create_sub_regions_inside_existing_region():
+    """A `{$dynamic}` block inside an already-region-wrapped element must
+    not create new sub-regions for its descendants — they should inline
+    into the parent region so wire reads register at the parent level."""
+    src = """---
+from pywire import wire
+count = wire(0)
+---
+<section>
+  <h2>plain</h2>
+  {$dynamic}
+    <ul><li>n={count}</li></ul>
+    <p>x={count}</p>
+  {/dynamic}
+</section>
+"""
+    parsed = PyWireParser().parse(src, "/virtual/dyn_inline.wire")
+    gen = CodeGenerator()
+    module_ast = gen.generate(parsed)
+    py_ast.fix_missing_locations(module_ast)
+    src_out = py_ast.unparse(module_ast)
+
+    # The section becomes a region. There should be exactly ONE region
+    # method for that section — descendants inside the dynamic block
+    # don't get their own region renderers.
+    region_methods = [
+        line for line in src_out.splitlines() if "async def _render_region_" in line
+    ]
+    assert len(region_methods) == 1, (
+        f"expected 1 region method for the section; got {len(region_methods)}:\n"
+        + "\n".join(region_methods)
+    )
+
+
+@pytest.mark.asyncio
+async def test_dynamic_block_tags_enclosing_region_in_dynamic_regions():
+    """The region enclosing a `{$dynamic}` block is added to
+    `__dynamic_regions__` so it force-dirties on every render — covers
+    the wire-free impure case."""
+    src = """---
+import datetime
+---
+<section>
+  <h2>title</h2>
+  {$dynamic}<p>now={datetime.datetime.now()}</p>{/dynamic}
+</section>
+"""
+    parsed = PyWireParser().parse(src, "/virtual/dyn_force_parent.wire")
+    gen = CodeGenerator()
+    module_ast = gen.generate(parsed)
+    py_ast.fix_missing_locations(module_ast)
+    src_out = py_ast.unparse(module_ast)
+
+    assert "__dynamic_regions__" in src_out, (
+        "expected enclosing region tagged in __dynamic_regions__\n" + src_out
+    )
+
+
+@pytest.mark.asyncio
+async def test_dynamic_section_sibling_display_advances_with_wire_bumps():
+    """End-to-end: a `<section>` containing a `{$dynamic}` block and a
+    sibling impure-display expression. After a wire bump the parent
+    region re-renders — both the inside-block rendering AND the sibling
+    counter display refresh."""
+    src = """---
+from pywire import wire
+
+_state = {"runs": 0}
+
+def tick() -> str:
+    _state["runs"] += 1
+    return ""
+
+def runs() -> int:
+    return _state["runs"]
+
+count = wire(0)
+---
+<section>
+  {$dynamic}
+    <p>{tick()}count={count}</p>
+  {/dynamic}
+  <p class="counter">runs={runs()}</p>
+</section>
+"""
+    cls = _compile_source(src, "dyn_sibling_display")
+    page = cls(_make_request(), {}, {})
+
+    h1 = await page._render_template()
+    assert "count=0" in h1
+    assert "runs=1" in h1
+
+    # Bump the wire — parent region must re-render so both `tick()` (inside
+    # the dynamic block) AND `runs()` (sibling display) reflect the bump.
+    page._expr_counts.clear()
+    page.count.value = 1
+
+    update = await page.render_update(init=False)
+    if update["type"] == "regions":
+        regions = update.get("regions", [])
+        combined = "".join(r["html"] for r in regions)
+    else:
+        combined = update.get("html", "")
+    assert "count=1" in combined, f"snippet body did not refresh: {combined!r}"
+    assert "runs=2" in combined, (
+        f"sibling display did not refresh after wire bump (was the parent "
+        f"region not invalidated?): {combined!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_invoke_component_dynamic_block_bypasses_cache():
+    src = """---
+---
+<p>p</p>
+"""
+    cls = _compile_source(src, "comp_dynamic_bypass")
+    page = cls(_make_request(), {}, {})
+
+    class _ChildPage(BasePage):
+        async def _render_and_cleanup(self) -> str:  # type: ignore[override]
+            self._render_calls = getattr(self, "_render_calls", 0) + 1
+            return "<span>c</span>"
+
+    child = _ChildPage(_make_request(), {}, {})
+    child.attrs = {"x": 1}
+
+    # Codegen sets _pw_bypass_memo=True for components inside a {$dynamic} block.
+    await page._invoke_component(child, _pw_bypass_memo=True)
+    await page._invoke_component(child, _pw_bypass_memo=True)
+    assert child._render_calls == 2  # bypass active — every call re-renders

--- a/packages/pywire/tests/test_no_interactive_directive.py
+++ b/packages/pywire/tests/test_no_interactive_directive.py
@@ -1,0 +1,107 @@
+"""Tests for ``!no_interactive`` directive (#128).
+
+Verifies:
+- The directive parses and lifts ``__no_interactive__ = True`` onto the
+  compiled page class.
+- Pages without the directive default to ``__no_interactive__ = False``.
+- The injected ``_pywire_spa_meta`` JSON carries ``page_interactive``
+  reflecting the page-level setting.
+"""
+
+from __future__ import annotations
+
+import ast as py_ast
+import json
+import re
+from typing import Any, Type
+
+import pytest
+from starlette.requests import Request
+
+from pywire_parser.parser import PyWireParser
+from pywire.compiler.codegen.generator import CodeGenerator
+from pywire.runtime.page import BasePage
+
+
+def _compile_source(source: str, module_name: str) -> Type[BasePage]:
+    parsed = PyWireParser().parse(source, f"/virtual/{module_name}.wire")
+    gen = CodeGenerator()
+    module_ast = gen.generate(parsed)
+    py_ast.fix_missing_locations(module_ast)
+    code = compile(module_ast, filename=f"<{module_name}>", mode="exec")
+    ns: dict[str, Any] = {"__name__": module_name}
+    exec(code, ns)
+    for name in reversed(list(ns.keys())):
+        v = ns[name]
+        if isinstance(v, type) and name.endswith("Page") and name != "BasePage":
+            return v
+    raise RuntimeError("No Page class was generated")
+
+
+def _make_request() -> Request:
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        "raw_path": b"/",
+        "query_string": b"",
+        "headers": [],
+        "client": ("127.0.0.1", 0),
+        "server": ("testserver", 80),
+        "scheme": "http",
+        "root_path": "",
+        "http_version": "1.1",
+    }
+    return Request(scope)
+
+
+def test_no_interactive_directive_sets_class_attr():
+    src = """!no_interactive
+---
+---
+<p>static</p>
+"""
+    cls = _compile_source(src, "ni_set")
+    assert getattr(cls, "__no_interactive__", None) is True
+
+
+def test_default_no_interactive_is_false():
+    src = """---
+---
+<p>regular</p>
+"""
+    cls = _compile_source(src, "ni_default")
+    assert getattr(cls, "__no_interactive__", None) is False
+
+
+@pytest.mark.asyncio
+async def test_meta_carries_page_interactive_false_when_directive_set():
+    src = """!no_interactive
+---
+---
+<html><head></head><body><p>x</p></body></html>
+"""
+    cls = _compile_source(src, "ni_meta_false")
+    page = cls(_make_request(), {}, {})
+    response = await page.render()
+    html = response.body.decode("utf-8")
+    m = re.search(r'<script id="_pywire_spa_meta"[^>]*>([^<]+)</script>', html)
+    assert m, "Expected _pywire_spa_meta script in rendered HTML"
+    meta = json.loads(m.group(1))
+    assert meta.get("page_interactive") is False
+
+
+@pytest.mark.asyncio
+async def test_meta_carries_page_interactive_true_by_default():
+    src = """---
+---
+<html><head></head><body><p>x</p></body></html>
+"""
+    cls = _compile_source(src, "ni_meta_true")
+    page = cls(_make_request(), {}, {})
+    response = await page.render()
+    html = response.body.decode("utf-8")
+    m = re.search(r'<script id="_pywire_spa_meta"[^>]*>([^<]+)</script>', html)
+    assert m, "Expected _pywire_spa_meta script in rendered HTML"
+    meta = json.loads(m.group(1))
+    assert meta.get("page_interactive") is True

--- a/packages/pywire/tests/test_oneliner_blocks.py
+++ b/packages/pywire/tests/test_oneliner_blocks.py
@@ -1,0 +1,120 @@
+"""Regression tests for oneliner brace-block syntax (#155).
+
+Single-line paired blocks like ``{$if cond}A{/if}`` compile cleanly
+through the existing block codegen — no special pathway needed.
+"""
+
+from __future__ import annotations
+
+import ast as py_ast
+from typing import Any, Type
+
+import pytest
+from starlette.requests import Request
+
+from pywire_parser.parser import PyWireParser
+from pywire.compiler.codegen.generator import CodeGenerator
+from pywire.runtime.page import BasePage
+
+
+def _compile_source(source: str, module_name: str) -> Type[BasePage]:
+    parsed = PyWireParser().parse(source, f"/virtual/{module_name}.wire")
+    gen = CodeGenerator()
+    module_ast = gen.generate(parsed)
+    py_ast.fix_missing_locations(module_ast)
+    code = compile(module_ast, filename=f"<{module_name}>", mode="exec")
+    ns: dict[str, Any] = {"__name__": module_name}
+    exec(code, ns)
+    for name in reversed(list(ns.keys())):
+        v = ns[name]
+        if isinstance(v, type) and name.endswith("Page") and name != "BasePage":
+            return v
+    raise RuntimeError("No Page class was generated")
+
+
+def _make_request() -> Request:
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        "raw_path": b"/",
+        "query_string": b"",
+        "headers": [],
+        "client": ("127.0.0.1", 0),
+        "server": ("testserver", 80),
+        "scheme": "http",
+        "root_path": "",
+        "http_version": "1.1",
+    }
+    return Request(scope)
+
+
+@pytest.mark.asyncio
+async def test_oneliner_if_truthy():
+    src = """---
+cond = True
+---
+<p>{$if cond}A{/if}</p>
+"""
+    cls = _compile_source(src, "ol_if_t")
+    page = cls(_make_request(), {}, {})
+    html = await page._render_template()
+    assert ">A</p>" in html
+
+
+@pytest.mark.asyncio
+async def test_oneliner_if_falsy():
+    src = """---
+cond = False
+---
+<p>{$if cond}A{/if}</p>
+"""
+    cls = _compile_source(src, "ol_if_f")
+    page = cls(_make_request(), {}, {})
+    html = await page._render_template()
+    assert "A" not in html
+
+
+@pytest.mark.asyncio
+async def test_oneliner_if_else():
+    src = """---
+cond = False
+---
+<p>{$if cond}A{$else}B{/if}</p>
+"""
+    cls = _compile_source(src, "ol_if_else")
+    page = cls(_make_request(), {}, {})
+    html = await page._render_template()
+    assert ">B</p>" in html
+    assert "A" not in html
+
+
+@pytest.mark.asyncio
+async def test_oneliner_for():
+    src = """---
+items = [1, 2, 3]
+---
+<ul>{$for it in items}<li>{it}</li>{/for}</ul>
+"""
+    cls = _compile_source(src, "ol_for")
+    page = cls(_make_request(), {}, {})
+    html = await page._render_template()
+    assert "<li>1</li>" in html
+    assert "<li>2</li>" in html
+    assert "<li>3</li>" in html
+
+
+@pytest.mark.asyncio
+async def test_chained_oneliner_ifs():
+    src = """---
+cond = True
+---
+<span>{$if cond}X{/if}{$if not cond}Y{/if}</span>
+"""
+    cls = _compile_source(src, "ol_chained")
+    page = cls(_make_request(), {}, {})
+    html = await page._render_template()
+    assert ">X" in html
+    # Whitespace from the {/if} → {$if not cond} gap may slip through;
+    # the assertion is that "Y" is excluded, not strict whitespace.
+    assert "Y" not in html

--- a/packages/tree-sitter-pywire/grammar.js
+++ b/packages/tree-sitter-pywire/grammar.js
@@ -214,7 +214,7 @@ module.exports = grammar({
 
         block_keyword: $ => choice(
             'if', 'for', 'try', 'await', 'auth', 'elif', 'else', 'finally', 'except', 'then', 'catch', 'html',
-            'snippet', 'render', 'head'
+            'snippet', 'render', 'head', 'dynamic'
         ),
 
         _python_code: $ => repeat1(choice(

--- a/packages/tree-sitter-pywire/src/grammar.json
+++ b/packages/tree-sitter-pywire/src/grammar.json
@@ -1001,6 +1001,10 @@
         {
           "type": "STRING",
           "value": "head"
+        },
+        {
+          "type": "STRING",
+          "value": "dynamic"
         }
       ]
     },

--- a/packages/tree-sitter-pywire/src/node-types.json
+++ b/packages/tree-sitter-pywire/src/node-types.json
@@ -606,6 +606,10 @@
     "named": true
   },
   {
+    "type": "dynamic",
+    "named": false
+  },
+  {
     "type": "elif",
     "named": false
   },

--- a/packages/tree-sitter-pywire/src/parser.c
+++ b/packages/tree-sitter-pywire/src/parser.c
@@ -17,9 +17,9 @@
 #define LANGUAGE_VERSION 14
 #define STATE_COUNT 157
 #define LARGE_STATE_COUNT 2
-#define SYMBOL_COUNT 89
+#define SYMBOL_COUNT 90
 #define ALIAS_COUNT 1
-#define TOKEN_COUNT 64
+#define TOKEN_COUNT 65
 #define EXTERNAL_TOKEN_COUNT 2
 #define FIELD_COUNT 6
 #define MAX_ALIAS_SEQUENCE_LENGTH 8
@@ -87,36 +87,37 @@ enum ts_symbol_identifiers {
   anon_sym_snippet = 57,
   anon_sym_render = 58,
   anon_sym_head = 59,
-  aux_sym__python_code_token1 = 60,
-  sym_comment = 61,
-  sym_hyphen = 62,
-  sym_bang = 63,
-  sym_source_file = 64,
-  sym_directives_section = 65,
-  sym_frontmatter = 66,
-  sym_template_section = 67,
-  sym__html_content = 68,
-  sym_tag = 69,
-  sym_self_closing_tag = 70,
-  sym_void_tag = 71,
-  sym_script_tag = 72,
-  sym_style_tag = 73,
-  aux_sym__script_content = 74,
-  aux_sym__style_content = 75,
-  sym_attribute = 76,
-  sym_attribute_shorthand = 77,
-  sym_spread_shorthand = 78,
-  sym_attribute_value = 79,
-  sym_text = 80,
-  sym_interpolation = 81,
-  sym_brace_block = 82,
-  sym_end_brace_block = 83,
-  sym_block_keyword = 84,
-  aux_sym__python_code = 85,
-  aux_sym_directives_section_repeat1 = 86,
-  aux_sym_template_section_repeat1 = 87,
-  aux_sym_tag_repeat1 = 88,
-  alias_sym_python_code = 89,
+  anon_sym_dynamic = 60,
+  aux_sym__python_code_token1 = 61,
+  sym_comment = 62,
+  sym_hyphen = 63,
+  sym_bang = 64,
+  sym_source_file = 65,
+  sym_directives_section = 66,
+  sym_frontmatter = 67,
+  sym_template_section = 68,
+  sym__html_content = 69,
+  sym_tag = 70,
+  sym_self_closing_tag = 71,
+  sym_void_tag = 72,
+  sym_script_tag = 73,
+  sym_style_tag = 74,
+  aux_sym__script_content = 75,
+  aux_sym__style_content = 76,
+  sym_attribute = 77,
+  sym_attribute_shorthand = 78,
+  sym_spread_shorthand = 79,
+  sym_attribute_value = 80,
+  sym_text = 81,
+  sym_interpolation = 82,
+  sym_brace_block = 83,
+  sym_end_brace_block = 84,
+  sym_block_keyword = 85,
+  aux_sym__python_code = 86,
+  aux_sym_directives_section_repeat1 = 87,
+  aux_sym_template_section_repeat1 = 88,
+  aux_sym_tag_repeat1 = 89,
+  alias_sym_python_code = 90,
 };
 
 static const char * const ts_symbol_names[] = {
@@ -180,6 +181,7 @@ static const char * const ts_symbol_names[] = {
   [anon_sym_snippet] = "snippet",
   [anon_sym_render] = "render",
   [anon_sym_head] = "head",
+  [anon_sym_dynamic] = "dynamic",
   [aux_sym__python_code_token1] = "_python_code_token1",
   [sym_comment] = "comment",
   [sym_hyphen] = "hyphen",
@@ -273,6 +275,7 @@ static const TSSymbol ts_symbol_map[] = {
   [anon_sym_snippet] = anon_sym_snippet,
   [anon_sym_render] = anon_sym_render,
   [anon_sym_head] = anon_sym_head,
+  [anon_sym_dynamic] = anon_sym_dynamic,
   [aux_sym__python_code_token1] = aux_sym__python_code_token1,
   [sym_comment] = sym_comment,
   [sym_hyphen] = sym_hyphen,
@@ -543,6 +546,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .named = false,
   },
   [anon_sym_head] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_dynamic] = {
     .visible = true,
     .named = false,
   },
@@ -935,33 +942,34 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(142);
+      if (eof) ADVANCE(148);
       ADVANCE_MAP(
-        '!', 317,
-        '"', 260,
-        '\'', 269,
+        '!', 324,
+        '"', 266,
+        '\'', 275,
         '*', 21,
-        '-', 315,
+        '-', 322,
         '/', 32,
-        '<', 162,
-        '=', 246,
-        '>', 166,
-        'a', 110,
+        '<', 168,
+        '=', 252,
+        '>', 172,
+        'a', 115,
         'b', 37,
         'c', 41,
-        'e', 87,
-        'f', 78,
-        'h', 63,
-        'i', 72,
-        'l', 80,
-        'm', 64,
+        'd', 135,
+        'e', 90,
+        'f', 85,
+        'h', 65,
+        'i', 74,
+        'l', 81,
+        'm', 66,
         'p', 42,
-        'r', 65,
-        's', 98,
-        't', 77,
-        'w', 47,
-        '{', 248,
-        '}', 249,
+        'r', 67,
+        's', 102,
+        't', 79,
+        'w', 48,
+        '{', 254,
+        '}', 255,
       );
       if (lookahead == '\t' ||
           lookahead == '\n' ||
@@ -970,20 +978,20 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 1:
       ADVANCE_MAP(
-        '\t', 203,
-        '<', 205,
-        'a', 236,
-        'b', 206,
-        'c', 231,
-        'e', 229,
-        'h', 234,
-        'i', 227,
-        'l', 223,
-        'm', 217,
-        'p', 211,
-        's', 232,
-        't', 237,
-        'w', 213,
+        '\t', 209,
+        '<', 211,
+        'a', 242,
+        'b', 212,
+        'c', 237,
+        'e', 235,
+        'h', 240,
+        'i', 233,
+        'l', 229,
+        'm', 223,
+        'p', 217,
+        's', 238,
+        't', 243,
+        'w', 219,
       );
       if (lookahead == '\n' ||
           lookahead == '\r' ||
@@ -994,19 +1002,19 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '/' &&
           (lookahead < '<' || '>' < lookahead) &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(245);
+          lookahead != '}') ADVANCE(251);
       END_STATE();
     case 2:
       ADVANCE_MAP(
-        '\t', 252,
-        '*', 255,
+        '\t', 258,
+        '*', 261,
         '/', 32,
-        '<', 254,
-        '=', 246,
-        '>', 166,
-        '{', 247,
-        ':', 257,
-        '@', 257,
+        '<', 260,
+        '=', 252,
+        '>', 172,
+        '{', 253,
+        ':', 263,
+        '@', 263,
       );
       if (lookahead == '\n' ||
           lookahead == '\r' ||
@@ -1014,26 +1022,26 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0 &&
           (lookahead < ' ' || '"' < lookahead) &&
           lookahead != '\'' &&
-          lookahead != '}') ADVANCE(258);
+          lookahead != '}') ADVANCE(264);
       END_STATE();
     case 3:
-      if (lookahead == '\t') ADVANCE(278);
-      if (lookahead == '"') ADVANCE(260);
-      if (lookahead == '\'') ADVANCE(269);
-      if (lookahead == '<') ADVANCE(279);
-      if (lookahead == '{') ADVANCE(247);
+      if (lookahead == '\t') ADVANCE(284);
+      if (lookahead == '"') ADVANCE(266);
+      if (lookahead == '\'') ADVANCE(275);
+      if (lookahead == '<') ADVANCE(285);
+      if (lookahead == '{') ADVANCE(253);
       if (lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(3);
       if (lookahead != 0 &&
           lookahead != '/' &&
           (lookahead < '<' || '>' < lookahead) &&
-          lookahead != '}') ADVANCE(285);
+          lookahead != '}') ADVANCE(291);
       END_STATE();
     case 4:
-      if (lookahead == '\t') ADVANCE(253);
-      if (lookahead == '*') ADVANCE(256);
-      if (lookahead == '<') ADVANCE(254);
+      if (lookahead == '\t') ADVANCE(259);
+      if (lookahead == '*') ADVANCE(262);
+      if (lookahead == '<') ADVANCE(260);
       if (lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(4);
@@ -1043,11 +1051,11 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '/' &&
           (lookahead < '<' || '>' < lookahead) &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(258);
+          lookahead != '}') ADVANCE(264);
       END_STATE();
     case 5:
-      if (lookahead == '\t') ADVANCE(204);
-      if (lookahead == '<') ADVANCE(205);
+      if (lookahead == '\t') ADVANCE(210);
+      if (lookahead == '<') ADVANCE(211);
       if (lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(5);
@@ -1057,13 +1065,13 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '/' &&
           (lookahead < '<' || '>' < lookahead) &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(245);
+          lookahead != '}') ADVANCE(251);
       END_STATE();
     case 6:
-      if (lookahead == '\n') ADVANCE(143);
+      if (lookahead == '\n') ADVANCE(149);
       END_STATE();
     case 7:
-      if (lookahead == '\n') ADVANCE(143);
+      if (lookahead == '\n') ADVANCE(149);
       if (lookahead == '\r') ADVANCE(6);
       if (lookahead == '{') ADVANCE(11);
       if (lookahead == '\t' ||
@@ -1075,7 +1083,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0) ADVANCE(9);
       END_STATE();
     case 8:
-      if (lookahead == '\n') ADVANCE(143);
+      if (lookahead == '\n') ADVANCE(149);
       if (lookahead == '\r') ADVANCE(6);
       if (lookahead == '{') ADVANCE(11);
       if (lookahead == '\t' ||
@@ -1083,42 +1091,42 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0) ADVANCE(9);
       END_STATE();
     case 9:
-      if (lookahead == '\n') ADVANCE(143);
+      if (lookahead == '\n') ADVANCE(149);
       if (lookahead == '\r') ADVANCE(6);
       if (lookahead != 0) ADVANCE(9);
       END_STATE();
     case 10:
-      if (lookahead == '\n') ADVANCE(144);
+      if (lookahead == '\n') ADVANCE(150);
       if (lookahead == '\r') ADVANCE(17);
       if (lookahead == '{') ADVANCE(18);
-      if (lookahead == '}') ADVANCE(147);
+      if (lookahead == '}') ADVANCE(153);
       if (lookahead != 0) ADVANCE(17);
       END_STATE();
     case 11:
-      if (lookahead == '\n') ADVANCE(144);
+      if (lookahead == '\n') ADVANCE(150);
       if (lookahead == '\r') ADVANCE(10);
       if (lookahead == '{') ADVANCE(15);
-      if (lookahead == '}') ADVANCE(147);
+      if (lookahead == '}') ADVANCE(153);
       if (lookahead != 0) ADVANCE(11);
       END_STATE();
     case 12:
-      if (lookahead == '\n') ADVANCE(148);
+      if (lookahead == '\n') ADVANCE(154);
       END_STATE();
     case 13:
-      if (lookahead == '\n') ADVANCE(148);
+      if (lookahead == '\n') ADVANCE(154);
       if (lookahead == '\r') ADVANCE(12);
       if (lookahead == '\t' ||
           lookahead == ' ') ADVANCE(13);
       END_STATE();
     case 14:
-      if (lookahead == '\n') ADVANCE(145);
+      if (lookahead == '\n') ADVANCE(151);
       if (lookahead == '\r') ADVANCE(18);
       if (lookahead == '}') ADVANCE(17);
       if (lookahead != 0 &&
           lookahead != '{') ADVANCE(18);
       END_STATE();
     case 15:
-      if (lookahead == '\n') ADVANCE(145);
+      if (lookahead == '\n') ADVANCE(151);
       if (lookahead == '\r') ADVANCE(14);
       if (lookahead == '{') ADVANCE(9);
       if (lookahead == '}') ADVANCE(11);
@@ -1126,17 +1134,17 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 16:
       if (lookahead == '\n') SKIP(16);
-      if (lookahead == '-') ADVANCE(157);
-      if (lookahead == '<') ADVANCE(153);
+      if (lookahead == '-') ADVANCE(163);
+      if (lookahead == '<') ADVANCE(159);
       if (lookahead == '\t' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(154);
-      if (lookahead != 0) ADVANCE(160);
+          lookahead == ' ') ADVANCE(160);
+      if (lookahead != 0) ADVANCE(166);
       END_STATE();
     case 17:
       if (lookahead == '\r') ADVANCE(17);
       if (lookahead == '{') ADVANCE(18);
-      if (lookahead == '}') ADVANCE(147);
+      if (lookahead == '}') ADVANCE(153);
       if (lookahead != 0) ADVANCE(17);
       END_STATE();
     case 18:
@@ -1146,22 +1154,22 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '{') ADVANCE(18);
       END_STATE();
     case 19:
-      if (lookahead == '!') ADVANCE(316);
-      if (lookahead == '-') ADVANCE(314);
-      if (lookahead == '<') ADVANCE(162);
-      if (lookahead == '{') ADVANCE(248);
+      if (lookahead == '!') ADVANCE(323);
+      if (lookahead == '-') ADVANCE(321);
+      if (lookahead == '<') ADVANCE(168);
+      if (lookahead == '{') ADVANCE(254);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(19);
       if (lookahead != 0 &&
-          lookahead != '}') ADVANCE(286);
+          lookahead != '}') ADVANCE(292);
       END_STATE();
     case 20:
       if (lookahead == '!') ADVANCE(25);
       END_STATE();
     case 21:
-      if (lookahead == '*') ADVANCE(250);
+      if (lookahead == '*') ADVANCE(256);
       END_STATE();
     case 22:
       if (lookahead == '-') ADVANCE(13);
@@ -1179,29 +1187,29 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
     case 26:
       if (lookahead == '-') ADVANCE(23);
       if (lookahead == 'D' ||
-          lookahead == 'd') ADVANCE(135);
+          lookahead == 'd') ADVANCE(141);
       END_STATE();
     case 27:
       if (lookahead == '-') ADVANCE(24);
       if (lookahead != 0) ADVANCE(27);
       END_STATE();
     case 28:
-      if (lookahead == '<') ADVANCE(305);
-      if (lookahead == '{') ADVANCE(247);
-      if (lookahead == '}') ADVANCE(249);
+      if (lookahead == '<') ADVANCE(312);
+      if (lookahead == '{') ADVANCE(253);
+      if (lookahead == '}') ADVANCE(255);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(310);
-      if (lookahead != 0) ADVANCE(312);
+          lookahead == ' ') ADVANCE(317);
+      if (lookahead != 0) ADVANCE(319);
       END_STATE();
     case 29:
-      if (lookahead == '<') ADVANCE(164);
+      if (lookahead == '<') ADVANCE(170);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(201);
-      if (lookahead != 0) ADVANCE(202);
+          lookahead == ' ') ADVANCE(207);
+      if (lookahead != 0) ADVANCE(208);
       END_STATE();
     case 30:
       if (lookahead == '<') ADVANCE(20);
@@ -1209,1141 +1217,1159 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(30);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(289);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(295);
       END_STATE();
     case 31:
-      if (lookahead == '<') ADVANCE(165);
+      if (lookahead == '<') ADVANCE(171);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(201);
-      if (lookahead != 0) ADVANCE(202);
+          lookahead == ' ') ADVANCE(207);
+      if (lookahead != 0) ADVANCE(208);
       END_STATE();
     case 32:
-      if (lookahead == '>') ADVANCE(168);
+      if (lookahead == '>') ADVANCE(174);
       END_STATE();
     case 33:
-      if (lookahead == '>') ADVANCE(313);
+      if (lookahead == '>') ADVANCE(320);
       END_STATE();
     case 34:
-      if (lookahead == '>') ADVANCE(161);
+      if (lookahead == '>') ADVANCE(167);
       if (lookahead != 0) ADVANCE(34);
       END_STATE();
     case 35:
-      if (lookahead == '>') ADVANCE(200);
+      if (lookahead == '>') ADVANCE(206);
       END_STATE();
     case 36:
-      if (lookahead == '>') ADVANCE(198);
+      if (lookahead == '>') ADVANCE(204);
       END_STATE();
     case 37:
-      if (lookahead == 'a') ADVANCE(115);
-      if (lookahead == 'r') ADVANCE(173);
+      if (lookahead == 'a') ADVANCE(120);
+      if (lookahead == 'r') ADVANCE(179);
       END_STATE();
     case 38:
-      if (lookahead == 'a') ADVANCE(55);
+      if (lookahead == 'a') ADVANCE(57);
       END_STATE();
     case 39:
-      if (lookahead == 'a') ADVANCE(169);
+      if (lookahead == 'a') ADVANCE(175);
       END_STATE();
     case 40:
-      if (lookahead == 'a') ADVANCE(187);
+      if (lookahead == 'a') ADVANCE(193);
       END_STATE();
     case 41:
-      if (lookahead == 'a') ADVANCE(124);
-      if (lookahead == 'o') ADVANCE(88);
+      if (lookahead == 'a') ADVANCE(129);
+      if (lookahead == 'o') ADVANCE(91);
       END_STATE();
     case 42:
-      if (lookahead == 'a') ADVANCE(111);
+      if (lookahead == 'a') ADVANCE(116);
       END_STATE();
     case 43:
-      if (lookahead == 'a') ADVANCE(94);
+      if (lookahead == 'a') ADVANCE(99);
       END_STATE();
     case 44:
-      if (lookahead == 'a') ADVANCE(82);
+      if (lookahead == 'a') ADVANCE(83);
       END_STATE();
     case 45:
-      if (lookahead == 'a') ADVANCE(50);
-      if (lookahead == 'y') ADVANCE(292);
+      if (lookahead == 'a') ADVANCE(52);
+      if (lookahead == 'y') ADVANCE(298);
       END_STATE();
     case 46:
-      if (lookahead == 'a') ADVANCE(91);
+      if (lookahead == 'a') ADVANCE(97);
       END_STATE();
     case 47:
-      if (lookahead == 'b') ADVANCE(108);
+      if (lookahead == 'a') ADVANCE(94);
       END_STATE();
     case 48:
-      if (lookahead == 'b') ADVANCE(67);
+      if (lookahead == 'b') ADVANCE(113);
       END_STATE();
     case 49:
-      if (lookahead == 'c') ADVANCE(76);
+      if (lookahead == 'b') ADVANCE(69);
       END_STATE();
     case 50:
-      if (lookahead == 'c') ADVANCE(86);
+      if (lookahead == 'c') ADVANCE(311);
       END_STATE();
     case 51:
-      if (lookahead == 'c') ADVANCE(113);
-      if (lookahead == 't') ADVANCE(131);
+      if (lookahead == 'c') ADVANCE(78);
       END_STATE();
     case 52:
-      if (lookahead == 'c') ADVANCE(66);
+      if (lookahead == 'c') ADVANCE(89);
       END_STATE();
     case 53:
-      if (lookahead == 'c') ADVANCE(61);
+      if (lookahead == 'c') ADVANCE(118);
+      if (lookahead == 't') ADVANCE(137);
       END_STATE();
     case 54:
-      if (lookahead == 'c') ADVANCE(114);
+      if (lookahead == 'c') ADVANCE(68);
       END_STATE();
     case 55:
-      if (lookahead == 'd') ADVANCE(304);
+      if (lookahead == 'c') ADVANCE(63);
       END_STATE();
     case 56:
-      if (lookahead == 'd') ADVANCE(177);
+      if (lookahead == 'c') ADVANCE(119);
       END_STATE();
     case 57:
-      if (lookahead == 'd') ADVANCE(70);
+      if (lookahead == 'd') ADVANCE(310);
       END_STATE();
     case 58:
-      if (lookahead == 'e') ADVANCE(171);
+      if (lookahead == 'd') ADVANCE(183);
       END_STATE();
     case 59:
-      if (lookahead == 'e') ADVANCE(296);
+      if (lookahead == 'd') ADVANCE(72);
       END_STATE();
     case 60:
-      if (lookahead == 'e') ADVANCE(199);
+      if (lookahead == 'e') ADVANCE(177);
       END_STATE();
     case 61:
-      if (lookahead == 'e') ADVANCE(191);
+      if (lookahead == 'e') ADVANCE(302);
       END_STATE();
     case 62:
-      if (lookahead == 'e') ADVANCE(35);
+      if (lookahead == 'e') ADVANCE(205);
       END_STATE();
     case 63:
-      if (lookahead == 'e') ADVANCE(38);
-      if (lookahead == 'r') ADVANCE(179);
-      if (lookahead == 't') ADVANCE(95);
+      if (lookahead == 'e') ADVANCE(197);
       END_STATE();
     case 64:
-      if (lookahead == 'e') ADVANCE(126);
+      if (lookahead == 'e') ADVANCE(35);
       END_STATE();
     case 65:
-      if (lookahead == 'e') ADVANCE(99);
+      if (lookahead == 'e') ADVANCE(38);
+      if (lookahead == 'r') ADVANCE(185);
+      if (lookahead == 't') ADVANCE(98);
       END_STATE();
     case 66:
-      if (lookahead == 'e') ADVANCE(103);
+      if (lookahead == 'e') ADVANCE(131);
       END_STATE();
     case 67:
-      if (lookahead == 'e') ADVANCE(56);
+      if (lookahead == 'e') ADVANCE(103);
       END_STATE();
     case 68:
-      if (lookahead == 'e') ADVANCE(39);
+      if (lookahead == 'e') ADVANCE(108);
       END_STATE();
     case 69:
-      if (lookahead == 'e') ADVANCE(97);
+      if (lookahead == 'e') ADVANCE(58);
       END_STATE();
     case 70:
-      if (lookahead == 'e') ADVANCE(109);
+      if (lookahead == 'e') ADVANCE(39);
       END_STATE();
     case 71:
-      if (lookahead == 'e') ADVANCE(123);
+      if (lookahead == 'e') ADVANCE(101);
       END_STATE();
     case 72:
-      if (lookahead == 'f') ADVANCE(290);
-      if (lookahead == 'm') ADVANCE(74);
-      if (lookahead == 'n') ADVANCE(101);
+      if (lookahead == 'e') ADVANCE(114);
       END_STATE();
     case 73:
-      if (lookahead == 'f') ADVANCE(295);
+      if (lookahead == 'e') ADVANCE(128);
       END_STATE();
     case 74:
-      if (lookahead == 'g') ADVANCE(181);
+      if (lookahead == 'f') ADVANCE(296);
+      if (lookahead == 'm') ADVANCE(76);
+      if (lookahead == 'n') ADVANCE(106);
       END_STATE();
     case 75:
-      if (lookahead == 'h') ADVANCE(294);
+      if (lookahead == 'f') ADVANCE(301);
       END_STATE();
     case 76:
-      if (lookahead == 'h') ADVANCE(300);
+      if (lookahead == 'g') ADVANCE(187);
       END_STATE();
     case 77:
-      if (lookahead == 'h') ADVANCE(69);
-      if (lookahead == 'r') ADVANCE(45);
+      if (lookahead == 'h') ADVANCE(300);
       END_STATE();
     case 78:
-      if (lookahead == 'i') ADVANCE(100);
-      if (lookahead == 'o') ADVANCE(107);
+      if (lookahead == 'h') ADVANCE(306);
       END_STATE();
     case 79:
-      if (lookahead == 'i') ADVANCE(73);
-      if (lookahead == 's') ADVANCE(59);
+      if (lookahead == 'h') ADVANCE(71);
+      if (lookahead == 'r') ADVANCE(45);
       END_STATE();
     case 80:
-      if (lookahead == 'i') ADVANCE(96);
+      if (lookahead == 'i') ADVANCE(75);
+      if (lookahead == 's') ADVANCE(61);
       END_STATE();
     case 81:
-      if (lookahead == 'i') ADVANCE(102);
+      if (lookahead == 'i') ADVANCE(100);
       END_STATE();
     case 82:
-      if (lookahead == 'i') ADVANCE(119);
+      if (lookahead == 'i') ADVANCE(107);
       END_STATE();
     case 83:
-      if (lookahead == 'i') ADVANCE(104);
+      if (lookahead == 'i') ADVANCE(124);
       END_STATE();
     case 84:
-      if (lookahead == 'i') ADVANCE(105);
+      if (lookahead == 'i') ADVANCE(50);
       END_STATE();
     case 85:
-      if (lookahead == 'k') ADVANCE(185);
+      if (lookahead == 'i') ADVANCE(105);
+      if (lookahead == 'o') ADVANCE(112);
       END_STATE();
     case 86:
-      if (lookahead == 'k') ADVANCE(193);
+      if (lookahead == 'i') ADVANCE(109);
       END_STATE();
     case 87:
-      if (lookahead == 'l') ADVANCE(79);
-      if (lookahead == 'm') ADVANCE(48);
-      if (lookahead == 'x') ADVANCE(52);
+      if (lookahead == 'i') ADVANCE(110);
       END_STATE();
     case 88:
-      if (lookahead == 'l') ADVANCE(175);
+      if (lookahead == 'k') ADVANCE(191);
       END_STATE();
     case 89:
-      if (lookahead == 'l') ADVANCE(301);
+      if (lookahead == 'k') ADVANCE(199);
       END_STATE();
     case 90:
-      if (lookahead == 'l') ADVANCE(130);
+      if (lookahead == 'l') ADVANCE(80);
+      if (lookahead == 'm') ADVANCE(49);
+      if (lookahead == 'x') ADVANCE(54);
       END_STATE();
     case 91:
-      if (lookahead == 'l') ADVANCE(90);
+      if (lookahead == 'l') ADVANCE(181);
       END_STATE();
     case 92:
-      if (lookahead == 'l') ADVANCE(60);
+      if (lookahead == 'l') ADVANCE(307);
       END_STATE();
     case 93:
-      if (lookahead == 'l') ADVANCE(62);
+      if (lookahead == 'l') ADVANCE(136);
       END_STATE();
     case 94:
-      if (lookahead == 'm') ADVANCE(189);
+      if (lookahead == 'l') ADVANCE(93);
       END_STATE();
     case 95:
-      if (lookahead == 'm') ADVANCE(89);
+      if (lookahead == 'l') ADVANCE(62);
       END_STATE();
     case 96:
-      if (lookahead == 'n') ADVANCE(85);
+      if (lookahead == 'l') ADVANCE(64);
       END_STATE();
     case 97:
-      if (lookahead == 'n') ADVANCE(299);
+      if (lookahead == 'm') ADVANCE(195);
       END_STATE();
     case 98:
-      if (lookahead == 'n') ADVANCE(81);
-      if (lookahead == 'o') ADVANCE(129);
+      if (lookahead == 'm') ADVANCE(92);
       END_STATE();
     case 99:
-      if (lookahead == 'n') ADVANCE(57);
+      if (lookahead == 'm') ADVANCE(84);
       END_STATE();
     case 100:
-      if (lookahead == 'n') ADVANCE(46);
+      if (lookahead == 'n') ADVANCE(88);
       END_STATE();
     case 101:
-      if (lookahead == 'p') ADVANCE(128);
+      if (lookahead == 'n') ADVANCE(305);
       END_STATE();
     case 102:
-      if (lookahead == 'p') ADVANCE(106);
+      if (lookahead == 'n') ADVANCE(82);
+      if (lookahead == 'o') ADVANCE(134);
       END_STATE();
     case 103:
-      if (lookahead == 'p') ADVANCE(121);
+      if (lookahead == 'n') ADVANCE(59);
       END_STATE();
     case 104:
-      if (lookahead == 'p') ADVANCE(122);
+      if (lookahead == 'n') ADVANCE(43);
       END_STATE();
     case 105:
-      if (lookahead == 'p') ADVANCE(125);
+      if (lookahead == 'n') ADVANCE(47);
       END_STATE();
     case 106:
-      if (lookahead == 'p') ADVANCE(71);
+      if (lookahead == 'p') ADVANCE(133);
       END_STATE();
     case 107:
-      if (lookahead == 'r') ADVANCE(291);
+      if (lookahead == 'p') ADVANCE(111);
       END_STATE();
     case 108:
-      if (lookahead == 'r') ADVANCE(195);
+      if (lookahead == 'p') ADVANCE(126);
       END_STATE();
     case 109:
-      if (lookahead == 'r') ADVANCE(303);
+      if (lookahead == 'p') ADVANCE(127);
       END_STATE();
     case 110:
-      if (lookahead == 'r') ADVANCE(68);
-      if (lookahead == 'u') ADVANCE(118);
-      if (lookahead == 'w') ADVANCE(44);
+      if (lookahead == 'p') ADVANCE(130);
       END_STATE();
     case 111:
-      if (lookahead == 'r') ADVANCE(43);
+      if (lookahead == 'p') ADVANCE(73);
       END_STATE();
     case 112:
-      if (lookahead == 'r') ADVANCE(53);
+      if (lookahead == 'r') ADVANCE(297);
       END_STATE();
     case 113:
-      if (lookahead == 'r') ADVANCE(83);
+      if (lookahead == 'r') ADVANCE(201);
       END_STATE();
     case 114:
-      if (lookahead == 'r') ADVANCE(84);
+      if (lookahead == 'r') ADVANCE(309);
       END_STATE();
     case 115:
-      if (lookahead == 's') ADVANCE(58);
+      if (lookahead == 'r') ADVANCE(70);
+      if (lookahead == 'u') ADVANCE(123);
+      if (lookahead == 'w') ADVANCE(44);
       END_STATE();
     case 116:
-      if (lookahead == 's') ADVANCE(54);
+      if (lookahead == 'r') ADVANCE(46);
       END_STATE();
     case 117:
-      if (lookahead == 's') ADVANCE(127);
+      if (lookahead == 'r') ADVANCE(55);
       END_STATE();
     case 118:
-      if (lookahead == 't') ADVANCE(75);
+      if (lookahead == 'r') ADVANCE(86);
       END_STATE();
     case 119:
-      if (lookahead == 't') ADVANCE(293);
+      if (lookahead == 'r') ADVANCE(87);
       END_STATE();
     case 120:
-      if (lookahead == 't') ADVANCE(183);
+      if (lookahead == 's') ADVANCE(60);
       END_STATE();
     case 121:
-      if (lookahead == 't') ADVANCE(298);
+      if (lookahead == 's') ADVANCE(56);
       END_STATE();
     case 122:
-      if (lookahead == 't') ADVANCE(197);
+      if (lookahead == 's') ADVANCE(132);
       END_STATE();
     case 123:
-      if (lookahead == 't') ADVANCE(302);
+      if (lookahead == 't') ADVANCE(77);
       END_STATE();
     case 124:
-      if (lookahead == 't') ADVANCE(49);
+      if (lookahead == 't') ADVANCE(299);
       END_STATE();
     case 125:
-      if (lookahead == 't') ADVANCE(36);
+      if (lookahead == 't') ADVANCE(189);
       END_STATE();
     case 126:
-      if (lookahead == 't') ADVANCE(40);
+      if (lookahead == 't') ADVANCE(304);
       END_STATE();
     case 127:
-      if (lookahead == 't') ADVANCE(132);
+      if (lookahead == 't') ADVANCE(203);
       END_STATE();
     case 128:
-      if (lookahead == 'u') ADVANCE(120);
+      if (lookahead == 't') ADVANCE(308);
       END_STATE();
     case 129:
-      if (lookahead == 'u') ADVANCE(112);
+      if (lookahead == 't') ADVANCE(51);
       END_STATE();
     case 130:
-      if (lookahead == 'y') ADVANCE(297);
+      if (lookahead == 't') ADVANCE(36);
       END_STATE();
     case 131:
-      if (lookahead == 'y') ADVANCE(92);
+      if (lookahead == 't') ADVANCE(40);
       END_STATE();
     case 132:
-      if (lookahead == 'y') ADVANCE(93);
+      if (lookahead == 't') ADVANCE(138);
       END_STATE();
     case 133:
-      if (lookahead == 'C' ||
-          lookahead == 'c') ADVANCE(137);
+      if (lookahead == 'u') ADVANCE(125);
       END_STATE();
     case 134:
+      if (lookahead == 'u') ADVANCE(117);
+      END_STATE();
+    case 135:
+      if (lookahead == 'y') ADVANCE(104);
+      END_STATE();
+    case 136:
+      if (lookahead == 'y') ADVANCE(303);
+      END_STATE();
+    case 137:
+      if (lookahead == 'y') ADVANCE(95);
+      END_STATE();
+    case 138:
+      if (lookahead == 'y') ADVANCE(96);
+      END_STATE();
+    case 139:
+      if (lookahead == 'C' ||
+          lookahead == 'c') ADVANCE(143);
+      END_STATE();
+    case 140:
       if (lookahead == 'E' ||
           lookahead == 'e') ADVANCE(34);
       END_STATE();
-    case 135:
-      if (lookahead == 'O' ||
-          lookahead == 'o') ADVANCE(133);
-      END_STATE();
-    case 136:
-      if (lookahead == 'P' ||
-          lookahead == 'p') ADVANCE(134);
-      END_STATE();
-    case 137:
-      if (lookahead == 'T' ||
-          lookahead == 't') ADVANCE(138);
-      END_STATE();
-    case 138:
-      if (lookahead == 'Y' ||
-          lookahead == 'y') ADVANCE(136);
-      END_STATE();
-    case 139:
-      if (eof) ADVANCE(142);
-      if (lookahead == '!') ADVANCE(317);
-      if (lookahead == '-') ADVANCE(315);
-      if (lookahead == '<') ADVANCE(163);
-      if (lookahead == '{') ADVANCE(248);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') SKIP(139);
-      if (lookahead != 0 &&
-          lookahead != '}') ADVANCE(286);
-      END_STATE();
-    case 140:
-      if (eof) ADVANCE(142);
-      if (lookahead == '!') ADVANCE(316);
-      if (lookahead == '-') ADVANCE(315);
-      if (lookahead == '<') ADVANCE(163);
-      if (lookahead == '{') ADVANCE(248);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') SKIP(140);
-      if (lookahead != 0 &&
-          lookahead != '}') ADVANCE(286);
-      END_STATE();
     case 141:
-      if (eof) ADVANCE(142);
-      if (lookahead == '!') ADVANCE(316);
-      if (lookahead == '-') ADVANCE(314);
-      if (lookahead == '<') ADVANCE(163);
-      if (lookahead == '{') ADVANCE(248);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') SKIP(141);
-      if (lookahead != 0 &&
-          lookahead != '}') ADVANCE(286);
+      if (lookahead == 'O' ||
+          lookahead == 'o') ADVANCE(139);
       END_STATE();
     case 142:
-      ACCEPT_TOKEN(ts_builtin_sym_end);
+      if (lookahead == 'P' ||
+          lookahead == 'p') ADVANCE(140);
       END_STATE();
     case 143:
-      ACCEPT_TOKEN(sym_directive);
+      if (lookahead == 'T' ||
+          lookahead == 't') ADVANCE(144);
       END_STATE();
     case 144:
+      if (lookahead == 'Y' ||
+          lookahead == 'y') ADVANCE(142);
+      END_STATE();
+    case 145:
+      if (eof) ADVANCE(148);
+      if (lookahead == '!') ADVANCE(324);
+      if (lookahead == '-') ADVANCE(322);
+      if (lookahead == '<') ADVANCE(169);
+      if (lookahead == '{') ADVANCE(254);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(145);
+      if (lookahead != 0 &&
+          lookahead != '}') ADVANCE(292);
+      END_STATE();
+    case 146:
+      if (eof) ADVANCE(148);
+      if (lookahead == '!') ADVANCE(323);
+      if (lookahead == '-') ADVANCE(322);
+      if (lookahead == '<') ADVANCE(169);
+      if (lookahead == '{') ADVANCE(254);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(146);
+      if (lookahead != 0 &&
+          lookahead != '}') ADVANCE(292);
+      END_STATE();
+    case 147:
+      if (eof) ADVANCE(148);
+      if (lookahead == '!') ADVANCE(323);
+      if (lookahead == '-') ADVANCE(321);
+      if (lookahead == '<') ADVANCE(169);
+      if (lookahead == '{') ADVANCE(254);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(147);
+      if (lookahead != 0 &&
+          lookahead != '}') ADVANCE(292);
+      END_STATE();
+    case 148:
+      ACCEPT_TOKEN(ts_builtin_sym_end);
+      END_STATE();
+    case 149:
+      ACCEPT_TOKEN(sym_directive);
+      END_STATE();
+    case 150:
       ACCEPT_TOKEN(sym_directive);
       if (lookahead == '\r') ADVANCE(17);
       if (lookahead == '{') ADVANCE(18);
-      if (lookahead == '}') ADVANCE(147);
+      if (lookahead == '}') ADVANCE(153);
       if (lookahead != 0) ADVANCE(17);
       END_STATE();
-    case 145:
+    case 151:
       ACCEPT_TOKEN(sym_directive);
       if (lookahead == '\r') ADVANCE(18);
       if (lookahead == '}') ADVANCE(17);
       if (lookahead != 0 &&
           lookahead != '{') ADVANCE(18);
       END_STATE();
-    case 146:
-      ACCEPT_TOKEN(sym_block_directive);
-      END_STATE();
-    case 147:
-      ACCEPT_TOKEN(sym_block_directive);
-      if (lookahead == '\n') ADVANCE(146);
-      END_STATE();
-    case 148:
-      ACCEPT_TOKEN(sym_separator);
-      END_STATE();
-    case 149:
-      ACCEPT_TOKEN(sym__python_content);
-      if (lookahead == '\n') ADVANCE(148);
-      if (lookahead == '\r') ADVANCE(150);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(149);
-      if (lookahead != 0) ADVANCE(160);
-      END_STATE();
-    case 150:
-      ACCEPT_TOKEN(sym__python_content);
-      if (lookahead == '\n') ADVANCE(148);
-      if (lookahead != 0) ADVANCE(160);
-      END_STATE();
-    case 151:
-      ACCEPT_TOKEN(sym__python_content);
-      if (lookahead == '\n') ADVANCE(27);
-      if (lookahead == '-') ADVANCE(159);
-      if (lookahead != 0) ADVANCE(152);
-      END_STATE();
     case 152:
-      ACCEPT_TOKEN(sym__python_content);
-      if (lookahead == '\n') ADVANCE(27);
-      if (lookahead == '-') ADVANCE(151);
-      if (lookahead != 0) ADVANCE(152);
+      ACCEPT_TOKEN(sym_block_directive);
       END_STATE();
     case 153:
-      ACCEPT_TOKEN(sym__python_content);
-      if (lookahead == '!') ADVANCE(158);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(160);
+      ACCEPT_TOKEN(sym_block_directive);
+      if (lookahead == '\n') ADVANCE(152);
       END_STATE();
     case 154:
-      ACCEPT_TOKEN(sym__python_content);
-      if (lookahead == '-') ADVANCE(157);
-      if (lookahead == '<') ADVANCE(153);
-      if (lookahead == '\t' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(154);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n') ADVANCE(160);
+      ACCEPT_TOKEN(sym_separator);
       END_STATE();
     case 155:
       ACCEPT_TOKEN(sym__python_content);
-      if (lookahead == '-') ADVANCE(149);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(160);
+      if (lookahead == '\n') ADVANCE(154);
+      if (lookahead == '\r') ADVANCE(156);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(155);
+      if (lookahead != 0) ADVANCE(166);
       END_STATE();
     case 156:
       ACCEPT_TOKEN(sym__python_content);
-      if (lookahead == '-') ADVANCE(152);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(160);
+      if (lookahead == '\n') ADVANCE(154);
+      if (lookahead != 0) ADVANCE(166);
       END_STATE();
     case 157:
       ACCEPT_TOKEN(sym__python_content);
-      if (lookahead == '-') ADVANCE(155);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(160);
+      if (lookahead == '\n') ADVANCE(27);
+      if (lookahead == '-') ADVANCE(165);
+      if (lookahead != 0) ADVANCE(158);
       END_STATE();
     case 158:
       ACCEPT_TOKEN(sym__python_content);
-      if (lookahead == '-') ADVANCE(156);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(160);
+      if (lookahead == '\n') ADVANCE(27);
+      if (lookahead == '-') ADVANCE(157);
+      if (lookahead != 0) ADVANCE(158);
       END_STATE();
     case 159:
       ACCEPT_TOKEN(sym__python_content);
-      if (lookahead == '>') ADVANCE(160);
+      if (lookahead == '!') ADVANCE(164);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(160);
+          lookahead != '\n') ADVANCE(166);
       END_STATE();
     case 160:
       ACCEPT_TOKEN(sym__python_content);
+      if (lookahead == '-') ADVANCE(163);
+      if (lookahead == '<') ADVANCE(159);
+      if (lookahead == '\t' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(160);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(160);
+          lookahead != '\t' &&
+          lookahead != '\n') ADVANCE(166);
       END_STATE();
     case 161:
-      ACCEPT_TOKEN(sym_doctype);
+      ACCEPT_TOKEN(sym__python_content);
+      if (lookahead == '-') ADVANCE(155);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(166);
       END_STATE();
     case 162:
-      ACCEPT_TOKEN(anon_sym_LT);
-      if (lookahead == '!') ADVANCE(26);
-      if (lookahead == '/') ADVANCE(167);
-      if (lookahead == 's') ADVANCE(51);
+      ACCEPT_TOKEN(sym__python_content);
+      if (lookahead == '-') ADVANCE(158);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(166);
       END_STATE();
     case 163:
-      ACCEPT_TOKEN(anon_sym_LT);
-      if (lookahead == '!') ADVANCE(26);
-      if (lookahead == 's') ADVANCE(51);
+      ACCEPT_TOKEN(sym__python_content);
+      if (lookahead == '-') ADVANCE(161);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(166);
       END_STATE();
     case 164:
-      ACCEPT_TOKEN(anon_sym_LT);
-      if (lookahead == '!') ADVANCE(25);
-      if (lookahead == '/') ADVANCE(117);
+      ACCEPT_TOKEN(sym__python_content);
+      if (lookahead == '-') ADVANCE(162);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(166);
       END_STATE();
     case 165:
-      ACCEPT_TOKEN(anon_sym_LT);
-      if (lookahead == '!') ADVANCE(25);
-      if (lookahead == '/') ADVANCE(116);
+      ACCEPT_TOKEN(sym__python_content);
+      if (lookahead == '>') ADVANCE(166);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(166);
       END_STATE();
     case 166:
-      ACCEPT_TOKEN(anon_sym_GT);
+      ACCEPT_TOKEN(sym__python_content);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(166);
       END_STATE();
     case 167:
-      ACCEPT_TOKEN(anon_sym_LT_SLASH);
+      ACCEPT_TOKEN(sym_doctype);
       END_STATE();
     case 168:
-      ACCEPT_TOKEN(anon_sym_SLASH_GT);
+      ACCEPT_TOKEN(anon_sym_LT);
+      if (lookahead == '!') ADVANCE(26);
+      if (lookahead == '/') ADVANCE(173);
+      if (lookahead == 's') ADVANCE(53);
       END_STATE();
     case 169:
-      ACCEPT_TOKEN(anon_sym_area);
+      ACCEPT_TOKEN(anon_sym_LT);
+      if (lookahead == '!') ADVANCE(26);
+      if (lookahead == 's') ADVANCE(53);
       END_STATE();
     case 170:
-      ACCEPT_TOKEN(anon_sym_area);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
+      ACCEPT_TOKEN(anon_sym_LT);
+      if (lookahead == '!') ADVANCE(25);
+      if (lookahead == '/') ADVANCE(122);
       END_STATE();
     case 171:
-      ACCEPT_TOKEN(anon_sym_base);
+      ACCEPT_TOKEN(anon_sym_LT);
+      if (lookahead == '!') ADVANCE(25);
+      if (lookahead == '/') ADVANCE(121);
       END_STATE();
     case 172:
-      ACCEPT_TOKEN(anon_sym_base);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
+      ACCEPT_TOKEN(anon_sym_GT);
       END_STATE();
     case 173:
-      ACCEPT_TOKEN(anon_sym_br);
+      ACCEPT_TOKEN(anon_sym_LT_SLASH);
       END_STATE();
     case 174:
-      ACCEPT_TOKEN(anon_sym_br);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
+      ACCEPT_TOKEN(anon_sym_SLASH_GT);
       END_STATE();
     case 175:
-      ACCEPT_TOKEN(anon_sym_col);
+      ACCEPT_TOKEN(anon_sym_area);
       END_STATE();
     case 176:
-      ACCEPT_TOKEN(anon_sym_col);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
+      ACCEPT_TOKEN(anon_sym_area);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 177:
-      ACCEPT_TOKEN(anon_sym_embed);
+      ACCEPT_TOKEN(anon_sym_base);
       END_STATE();
     case 178:
-      ACCEPT_TOKEN(anon_sym_embed);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
+      ACCEPT_TOKEN(anon_sym_base);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 179:
-      ACCEPT_TOKEN(anon_sym_hr);
+      ACCEPT_TOKEN(anon_sym_br);
       END_STATE();
     case 180:
-      ACCEPT_TOKEN(anon_sym_hr);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
+      ACCEPT_TOKEN(anon_sym_br);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 181:
-      ACCEPT_TOKEN(anon_sym_img);
+      ACCEPT_TOKEN(anon_sym_col);
       END_STATE();
     case 182:
-      ACCEPT_TOKEN(anon_sym_img);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
+      ACCEPT_TOKEN(anon_sym_col);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 183:
-      ACCEPT_TOKEN(anon_sym_input);
+      ACCEPT_TOKEN(anon_sym_embed);
       END_STATE();
     case 184:
-      ACCEPT_TOKEN(anon_sym_input);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
+      ACCEPT_TOKEN(anon_sym_embed);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 185:
-      ACCEPT_TOKEN(anon_sym_link);
+      ACCEPT_TOKEN(anon_sym_hr);
       END_STATE();
     case 186:
-      ACCEPT_TOKEN(anon_sym_link);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
+      ACCEPT_TOKEN(anon_sym_hr);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 187:
-      ACCEPT_TOKEN(anon_sym_meta);
+      ACCEPT_TOKEN(anon_sym_img);
       END_STATE();
     case 188:
-      ACCEPT_TOKEN(anon_sym_meta);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
+      ACCEPT_TOKEN(anon_sym_img);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 189:
-      ACCEPT_TOKEN(anon_sym_param);
+      ACCEPT_TOKEN(anon_sym_input);
       END_STATE();
     case 190:
-      ACCEPT_TOKEN(anon_sym_param);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
+      ACCEPT_TOKEN(anon_sym_input);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 191:
-      ACCEPT_TOKEN(anon_sym_source);
+      ACCEPT_TOKEN(anon_sym_link);
       END_STATE();
     case 192:
-      ACCEPT_TOKEN(anon_sym_source);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
+      ACCEPT_TOKEN(anon_sym_link);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 193:
-      ACCEPT_TOKEN(anon_sym_track);
+      ACCEPT_TOKEN(anon_sym_meta);
       END_STATE();
     case 194:
-      ACCEPT_TOKEN(anon_sym_track);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
+      ACCEPT_TOKEN(anon_sym_meta);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 195:
-      ACCEPT_TOKEN(anon_sym_wbr);
+      ACCEPT_TOKEN(anon_sym_param);
       END_STATE();
     case 196:
-      ACCEPT_TOKEN(anon_sym_wbr);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
+      ACCEPT_TOKEN(anon_sym_param);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 197:
-      ACCEPT_TOKEN(anon_sym_LTscript);
+      ACCEPT_TOKEN(anon_sym_source);
       END_STATE();
     case 198:
-      ACCEPT_TOKEN(anon_sym_LT_SLASHscript_GT);
+      ACCEPT_TOKEN(anon_sym_source);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 199:
-      ACCEPT_TOKEN(anon_sym_LTstyle);
+      ACCEPT_TOKEN(anon_sym_track);
       END_STATE();
     case 200:
-      ACCEPT_TOKEN(anon_sym_LT_SLASHstyle_GT);
+      ACCEPT_TOKEN(anon_sym_track);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 201:
+      ACCEPT_TOKEN(anon_sym_wbr);
+      END_STATE();
+    case 202:
+      ACCEPT_TOKEN(anon_sym_wbr);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
+      END_STATE();
+    case 203:
+      ACCEPT_TOKEN(anon_sym_LTscript);
+      END_STATE();
+    case 204:
+      ACCEPT_TOKEN(anon_sym_LT_SLASHscript_GT);
+      END_STATE();
+    case 205:
+      ACCEPT_TOKEN(anon_sym_LTstyle);
+      END_STATE();
+    case 206:
+      ACCEPT_TOKEN(anon_sym_LT_SLASHstyle_GT);
+      END_STATE();
+    case 207:
       ACCEPT_TOKEN(aux_sym__script_content_token1);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(201);
+          lookahead == ' ') ADVANCE(207);
       if (lookahead != 0 &&
-          lookahead != '<') ADVANCE(202);
-      END_STATE();
-    case 202:
-      ACCEPT_TOKEN(aux_sym__script_content_token1);
-      if (lookahead != 0 &&
-          lookahead != '<') ADVANCE(202);
-      END_STATE();
-    case 203:
-      ACCEPT_TOKEN(sym_tag_name);
-      ADVANCE_MAP(
-        '\t', 203,
-        '<', 205,
-        'a', 236,
-        'b', 206,
-        'c', 231,
-        'e', 229,
-        'h', 234,
-        'i', 227,
-        'l', 223,
-        'm', 217,
-        'p', 211,
-        's', 232,
-        't', 237,
-        'w', 213,
-      );
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
-      END_STATE();
-    case 204:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == '\t') ADVANCE(204);
-      if (lookahead == '<') ADVANCE(205);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
-      END_STATE();
-    case 205:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == '!') ADVANCE(25);
-      if ((!eof && set_contains(aux_sym_attribute_value_token3_character_set_1, 10, lookahead))) ADVANCE(245);
-      END_STATE();
-    case 206:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'a') ADVANCE(240);
-      if (lookahead == 'r') ADVANCE(174);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
-      END_STATE();
-    case 207:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'a') ADVANCE(214);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
+          lookahead != '<') ADVANCE(208);
       END_STATE();
     case 208:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'a') ADVANCE(170);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
+      ACCEPT_TOKEN(aux_sym__script_content_token1);
+      if (lookahead != 0 &&
+          lookahead != '<') ADVANCE(208);
       END_STATE();
     case 209:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'a') ADVANCE(188);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
+      ADVANCE_MAP(
+        '\t', 209,
+        '<', 211,
+        'a', 242,
+        'b', 212,
+        'c', 237,
+        'e', 235,
+        'h', 240,
+        'i', 233,
+        'l', 229,
+        'm', 223,
+        'p', 217,
+        's', 238,
+        't', 243,
+        'w', 219,
+      );
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 210:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'a') ADVANCE(228);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
+      if (lookahead == '\t') ADVANCE(210);
+      if (lookahead == '<') ADVANCE(211);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 211:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'a') ADVANCE(239);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
+      if (lookahead == '!') ADVANCE(25);
+      if ((!eof && set_contains(aux_sym_attribute_value_token3_character_set_1, 10, lookahead))) ADVANCE(251);
       END_STATE();
     case 212:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'b') ADVANCE(219);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
+      if (lookahead == 'a') ADVANCE(246);
+      if (lookahead == 'r') ADVANCE(180);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 213:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'b') ADVANCE(235);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
+      if (lookahead == 'a') ADVANCE(220);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 214:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'c') ADVANCE(225);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
+      if (lookahead == 'a') ADVANCE(176);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 215:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'c') ADVANCE(220);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
+      if (lookahead == 'a') ADVANCE(194);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 216:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'd') ADVANCE(178);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
+      if (lookahead == 'a') ADVANCE(234);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 217:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'e') ADVANCE(242);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
+      if (lookahead == 'a') ADVANCE(245);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 218:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'e') ADVANCE(172);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
+      if (lookahead == 'b') ADVANCE(225);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 219:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'e') ADVANCE(216);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
+      if (lookahead == 'b') ADVANCE(241);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 220:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'e') ADVANCE(192);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
+      if (lookahead == 'c') ADVANCE(231);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 221:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'e') ADVANCE(208);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
+      if (lookahead == 'c') ADVANCE(226);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 222:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'g') ADVANCE(182);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
+      if (lookahead == 'd') ADVANCE(184);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 223:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'i') ADVANCE(230);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
+      if (lookahead == 'e') ADVANCE(248);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 224:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'k') ADVANCE(186);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
+      if (lookahead == 'e') ADVANCE(178);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 225:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'k') ADVANCE(194);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
+      if (lookahead == 'e') ADVANCE(222);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 226:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'l') ADVANCE(176);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
+      if (lookahead == 'e') ADVANCE(198);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 227:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'm') ADVANCE(222);
-      if (lookahead == 'n') ADVANCE(233);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
+      if (lookahead == 'e') ADVANCE(214);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 228:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'm') ADVANCE(190);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
+      if (lookahead == 'g') ADVANCE(188);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 229:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'm') ADVANCE(212);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
+      if (lookahead == 'i') ADVANCE(236);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 230:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'n') ADVANCE(224);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
+      if (lookahead == 'k') ADVANCE(192);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 231:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'o') ADVANCE(226);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
+      if (lookahead == 'k') ADVANCE(200);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 232:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'o') ADVANCE(244);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
+      if (lookahead == 'l') ADVANCE(182);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 233:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'p') ADVANCE(243);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
+      if (lookahead == 'm') ADVANCE(228);
+      if (lookahead == 'n') ADVANCE(239);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 234:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'r') ADVANCE(180);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
+      if (lookahead == 'm') ADVANCE(196);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 235:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'r') ADVANCE(196);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
+      if (lookahead == 'm') ADVANCE(218);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 236:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'r') ADVANCE(221);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
+      if (lookahead == 'n') ADVANCE(230);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 237:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'r') ADVANCE(207);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
+      if (lookahead == 'o') ADVANCE(232);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 238:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'r') ADVANCE(215);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
+      if (lookahead == 'o') ADVANCE(250);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 239:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'r') ADVANCE(210);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
+      if (lookahead == 'p') ADVANCE(249);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 240:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 's') ADVANCE(218);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
+      if (lookahead == 'r') ADVANCE(186);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 241:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 't') ADVANCE(184);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
+      if (lookahead == 'r') ADVANCE(202);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 242:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 't') ADVANCE(209);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
+      if (lookahead == 'r') ADVANCE(227);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 243:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'u') ADVANCE(241);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
+      if (lookahead == 'r') ADVANCE(213);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 244:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'u') ADVANCE(238);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
+      if (lookahead == 'r') ADVANCE(221);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 245:
       ACCEPT_TOKEN(sym_tag_name);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(245);
+      if (lookahead == 'r') ADVANCE(216);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 246:
-      ACCEPT_TOKEN(anon_sym_EQ);
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 's') ADVANCE(224);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 247:
-      ACCEPT_TOKEN(anon_sym_LBRACE);
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 't') ADVANCE(190);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 248:
-      ACCEPT_TOKEN(anon_sym_LBRACE);
-      if (lookahead == '$') ADVANCE(287);
-      if (lookahead == '/') ADVANCE(288);
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 't') ADVANCE(215);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 249:
-      ACCEPT_TOKEN(anon_sym_RBRACE);
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'u') ADVANCE(247);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 250:
-      ACCEPT_TOKEN(anon_sym_STAR_STAR);
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'u') ADVANCE(244);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 251:
-      ACCEPT_TOKEN(anon_sym_STAR_STAR);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(258);
+      ACCEPT_TOKEN(sym_tag_name);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(251);
       END_STATE();
     case 252:
-      ACCEPT_TOKEN(sym_attribute_name);
-      if (lookahead == '\t') ADVANCE(252);
-      if (lookahead == '*') ADVANCE(255);
-      if (lookahead == '<') ADVANCE(254);
-      if (lookahead == ':' ||
-          lookahead == '@') ADVANCE(257);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(258);
+      ACCEPT_TOKEN(anon_sym_EQ);
       END_STATE();
     case 253:
-      ACCEPT_TOKEN(sym_attribute_name);
-      if (lookahead == '\t') ADVANCE(253);
-      if (lookahead == '*') ADVANCE(256);
-      if (lookahead == '<') ADVANCE(254);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(258);
+      ACCEPT_TOKEN(anon_sym_LBRACE);
       END_STATE();
     case 254:
-      ACCEPT_TOKEN(sym_attribute_name);
-      if (lookahead == '!') ADVANCE(25);
-      if ((!eof && set_contains(aux_sym_attribute_value_token3_character_set_1, 10, lookahead))) ADVANCE(258);
+      ACCEPT_TOKEN(anon_sym_LBRACE);
+      if (lookahead == '$') ADVANCE(293);
+      if (lookahead == '/') ADVANCE(294);
       END_STATE();
     case 255:
-      ACCEPT_TOKEN(sym_attribute_name);
-      if (lookahead == '*') ADVANCE(257);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(258);
+      ACCEPT_TOKEN(anon_sym_RBRACE);
       END_STATE();
     case 256:
-      ACCEPT_TOKEN(sym_attribute_name);
-      if (lookahead == '*') ADVANCE(251);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(258);
+      ACCEPT_TOKEN(anon_sym_STAR_STAR);
       END_STATE();
     case 257:
-      ACCEPT_TOKEN(sym_attribute_name);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(259);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(258);
+      ACCEPT_TOKEN(anon_sym_STAR_STAR);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(264);
       END_STATE();
     case 258:
       ACCEPT_TOKEN(sym_attribute_name);
-      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(258);
+      if (lookahead == '\t') ADVANCE(258);
+      if (lookahead == '*') ADVANCE(261);
+      if (lookahead == '<') ADVANCE(260);
+      if (lookahead == ':' ||
+          lookahead == '@') ADVANCE(263);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(264);
       END_STATE();
     case 259:
+      ACCEPT_TOKEN(sym_attribute_name);
+      if (lookahead == '\t') ADVANCE(259);
+      if (lookahead == '*') ADVANCE(262);
+      if (lookahead == '<') ADVANCE(260);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(264);
+      END_STATE();
+    case 260:
+      ACCEPT_TOKEN(sym_attribute_name);
+      if (lookahead == '!') ADVANCE(25);
+      if ((!eof && set_contains(aux_sym_attribute_value_token3_character_set_1, 10, lookahead))) ADVANCE(264);
+      END_STATE();
+    case 261:
+      ACCEPT_TOKEN(sym_attribute_name);
+      if (lookahead == '*') ADVANCE(263);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(264);
+      END_STATE();
+    case 262:
+      ACCEPT_TOKEN(sym_attribute_name);
+      if (lookahead == '*') ADVANCE(257);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(264);
+      END_STATE();
+    case 263:
+      ACCEPT_TOKEN(sym_attribute_name);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(265);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(264);
+      END_STATE();
+    case 264:
+      ACCEPT_TOKEN(sym_attribute_name);
+      if ((!eof && set_contains(sym_tag_name_character_set_1, 9, lookahead))) ADVANCE(264);
+      END_STATE();
+    case 265:
       ACCEPT_TOKEN(sym_special_attribute_name);
       if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(259);
-      END_STATE();
-    case 260:
-      ACCEPT_TOKEN(anon_sym_DQUOTE);
-      END_STATE();
-    case 261:
-      ACCEPT_TOKEN(aux_sym_attribute_value_token1);
-      if (lookahead == '!') ADVANCE(265);
-      if (lookahead != 0 &&
-          lookahead != '!' &&
-          lookahead != '"') ADVANCE(268);
-      END_STATE();
-    case 262:
-      ACCEPT_TOKEN(aux_sym_attribute_value_token1);
-      if (lookahead == '"') ADVANCE(27);
-      if (lookahead == '-') ADVANCE(267);
-      if (lookahead != 0) ADVANCE(263);
-      END_STATE();
-    case 263:
-      ACCEPT_TOKEN(aux_sym_attribute_value_token1);
-      if (lookahead == '"') ADVANCE(27);
-      if (lookahead == '-') ADVANCE(262);
-      if (lookahead != 0) ADVANCE(263);
-      END_STATE();
-    case 264:
-      ACCEPT_TOKEN(aux_sym_attribute_value_token1);
-      if (lookahead == '-') ADVANCE(263);
-      if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(268);
-      END_STATE();
-    case 265:
-      ACCEPT_TOKEN(aux_sym_attribute_value_token1);
-      if (lookahead == '-') ADVANCE(264);
-      if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(268);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(265);
       END_STATE();
     case 266:
-      ACCEPT_TOKEN(aux_sym_attribute_value_token1);
-      if (lookahead == '<') ADVANCE(261);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(266);
-      if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(268);
+      ACCEPT_TOKEN(anon_sym_DQUOTE);
       END_STATE();
     case 267:
       ACCEPT_TOKEN(aux_sym_attribute_value_token1);
-      if (lookahead == '>') ADVANCE(268);
+      if (lookahead == '!') ADVANCE(271);
       if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(268);
+          lookahead != '!' &&
+          lookahead != '"') ADVANCE(274);
       END_STATE();
     case 268:
       ACCEPT_TOKEN(aux_sym_attribute_value_token1);
-      if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(268);
+      if (lookahead == '"') ADVANCE(27);
+      if (lookahead == '-') ADVANCE(273);
+      if (lookahead != 0) ADVANCE(269);
       END_STATE();
     case 269:
-      ACCEPT_TOKEN(anon_sym_SQUOTE);
+      ACCEPT_TOKEN(aux_sym_attribute_value_token1);
+      if (lookahead == '"') ADVANCE(27);
+      if (lookahead == '-') ADVANCE(268);
+      if (lookahead != 0) ADVANCE(269);
       END_STATE();
     case 270:
-      ACCEPT_TOKEN(aux_sym_attribute_value_token2);
-      if (lookahead == '!') ADVANCE(274);
+      ACCEPT_TOKEN(aux_sym_attribute_value_token1);
+      if (lookahead == '-') ADVANCE(269);
       if (lookahead != 0 &&
-          lookahead != '\'') ADVANCE(277);
+          lookahead != '"') ADVANCE(274);
       END_STATE();
     case 271:
-      ACCEPT_TOKEN(aux_sym_attribute_value_token2);
-      if (lookahead == '\'') ADVANCE(27);
-      if (lookahead == '-') ADVANCE(276);
-      if (lookahead != 0) ADVANCE(272);
+      ACCEPT_TOKEN(aux_sym_attribute_value_token1);
+      if (lookahead == '-') ADVANCE(270);
+      if (lookahead != 0 &&
+          lookahead != '"') ADVANCE(274);
       END_STATE();
     case 272:
-      ACCEPT_TOKEN(aux_sym_attribute_value_token2);
-      if (lookahead == '\'') ADVANCE(27);
-      if (lookahead == '-') ADVANCE(271);
-      if (lookahead != 0) ADVANCE(272);
-      END_STATE();
-    case 273:
-      ACCEPT_TOKEN(aux_sym_attribute_value_token2);
-      if (lookahead == '-') ADVANCE(272);
-      if (lookahead != 0 &&
-          lookahead != '\'') ADVANCE(277);
-      END_STATE();
-    case 274:
-      ACCEPT_TOKEN(aux_sym_attribute_value_token2);
-      if (lookahead == '-') ADVANCE(273);
-      if (lookahead != 0 &&
-          lookahead != '\'') ADVANCE(277);
-      END_STATE();
-    case 275:
-      ACCEPT_TOKEN(aux_sym_attribute_value_token2);
-      if (lookahead == '<') ADVANCE(270);
+      ACCEPT_TOKEN(aux_sym_attribute_value_token1);
+      if (lookahead == '<') ADVANCE(267);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(275);
+          lookahead == ' ') ADVANCE(272);
       if (lookahead != 0 &&
-          lookahead != '\'') ADVANCE(277);
+          lookahead != '"') ADVANCE(274);
+      END_STATE();
+    case 273:
+      ACCEPT_TOKEN(aux_sym_attribute_value_token1);
+      if (lookahead == '>') ADVANCE(274);
+      if (lookahead != 0 &&
+          lookahead != '"') ADVANCE(274);
+      END_STATE();
+    case 274:
+      ACCEPT_TOKEN(aux_sym_attribute_value_token1);
+      if (lookahead != 0 &&
+          lookahead != '"') ADVANCE(274);
+      END_STATE();
+    case 275:
+      ACCEPT_TOKEN(anon_sym_SQUOTE);
       END_STATE();
     case 276:
       ACCEPT_TOKEN(aux_sym_attribute_value_token2);
-      if (lookahead == '>') ADVANCE(277);
+      if (lookahead == '!') ADVANCE(280);
       if (lookahead != 0 &&
-          lookahead != '\'') ADVANCE(277);
+          lookahead != '\'') ADVANCE(283);
       END_STATE();
     case 277:
       ACCEPT_TOKEN(aux_sym_attribute_value_token2);
-      if (lookahead != 0 &&
-          lookahead != '\'') ADVANCE(277);
+      if (lookahead == '\'') ADVANCE(27);
+      if (lookahead == '-') ADVANCE(282);
+      if (lookahead != 0) ADVANCE(278);
       END_STATE();
     case 278:
-      ACCEPT_TOKEN(aux_sym_attribute_value_token3);
-      if (lookahead == '\t') ADVANCE(278);
-      if (lookahead == '<') ADVANCE(279);
-      if ((!eof && set_contains(aux_sym_attribute_value_token3_character_set_1, 10, lookahead))) ADVANCE(285);
+      ACCEPT_TOKEN(aux_sym_attribute_value_token2);
+      if (lookahead == '\'') ADVANCE(27);
+      if (lookahead == '-') ADVANCE(277);
+      if (lookahead != 0) ADVANCE(278);
       END_STATE();
     case 279:
-      ACCEPT_TOKEN(aux_sym_attribute_value_token3);
-      if (lookahead == '!') ADVANCE(282);
-      if ((!eof && set_contains(aux_sym_attribute_value_token3_character_set_1, 10, lookahead))) ADVANCE(285);
+      ACCEPT_TOKEN(aux_sym_attribute_value_token2);
+      if (lookahead == '-') ADVANCE(278);
+      if (lookahead != 0 &&
+          lookahead != '\'') ADVANCE(283);
       END_STATE();
     case 280:
-      ACCEPT_TOKEN(aux_sym_attribute_value_token3);
-      if (lookahead == '-') ADVANCE(283);
-      if ((!eof && set_contains(aux_sym_attribute_value_token3_character_set_1, 10, lookahead))) ADVANCE(285);
+      ACCEPT_TOKEN(aux_sym_attribute_value_token2);
+      if (lookahead == '-') ADVANCE(279);
+      if (lookahead != 0 &&
+          lookahead != '\'') ADVANCE(283);
       END_STATE();
     case 281:
-      ACCEPT_TOKEN(aux_sym_attribute_value_token3);
-      ADVANCE_MAP(
-        '-', 284,
-        '\n', 27,
-        '\r', 27,
-        ' ', 27,
-        '"', 27,
-        '\'', 27,
-        '/', 27,
-        '=', 27,
-        '>', 27,
-        '{', 27,
-        '}', 27,
-      );
-      if (lookahead != 0) ADVANCE(283);
+      ACCEPT_TOKEN(aux_sym_attribute_value_token2);
+      if (lookahead == '<') ADVANCE(276);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(281);
+      if (lookahead != 0 &&
+          lookahead != '\'') ADVANCE(283);
       END_STATE();
     case 282:
-      ACCEPT_TOKEN(aux_sym_attribute_value_token3);
-      if (lookahead == '-') ADVANCE(280);
-      if ((!eof && set_contains(aux_sym_attribute_value_token3_character_set_1, 10, lookahead))) ADVANCE(285);
+      ACCEPT_TOKEN(aux_sym_attribute_value_token2);
+      if (lookahead == '>') ADVANCE(283);
+      if (lookahead != 0 &&
+          lookahead != '\'') ADVANCE(283);
       END_STATE();
     case 283:
-      ACCEPT_TOKEN(aux_sym_attribute_value_token3);
-      ADVANCE_MAP(
-        '-', 281,
-        '\n', 27,
-        '\r', 27,
-        ' ', 27,
-        '"', 27,
-        '\'', 27,
-        '/', 27,
-        '=', 27,
-        '>', 27,
-        '{', 27,
-        '}', 27,
-      );
-      if (lookahead != 0) ADVANCE(283);
+      ACCEPT_TOKEN(aux_sym_attribute_value_token2);
+      if (lookahead != 0 &&
+          lookahead != '\'') ADVANCE(283);
       END_STATE();
     case 284:
       ACCEPT_TOKEN(aux_sym_attribute_value_token3);
-      if (lookahead == '>') ADVANCE(313);
-      if ((!eof && set_contains(aux_sym_attribute_value_token3_character_set_1, 10, lookahead))) ADVANCE(285);
+      if (lookahead == '\t') ADVANCE(284);
+      if (lookahead == '<') ADVANCE(285);
+      if ((!eof && set_contains(aux_sym_attribute_value_token3_character_set_1, 10, lookahead))) ADVANCE(291);
       END_STATE();
     case 285:
       ACCEPT_TOKEN(aux_sym_attribute_value_token3);
-      if ((!eof && set_contains(aux_sym_attribute_value_token3_character_set_1, 10, lookahead))) ADVANCE(285);
+      if (lookahead == '!') ADVANCE(288);
+      if ((!eof && set_contains(aux_sym_attribute_value_token3_character_set_1, 10, lookahead))) ADVANCE(291);
       END_STATE();
     case 286:
+      ACCEPT_TOKEN(aux_sym_attribute_value_token3);
+      if (lookahead == '-') ADVANCE(289);
+      if ((!eof && set_contains(aux_sym_attribute_value_token3_character_set_1, 10, lookahead))) ADVANCE(291);
+      END_STATE();
+    case 287:
+      ACCEPT_TOKEN(aux_sym_attribute_value_token3);
+      ADVANCE_MAP(
+        '-', 290,
+        '\n', 27,
+        '\r', 27,
+        ' ', 27,
+        '"', 27,
+        '\'', 27,
+        '/', 27,
+        '=', 27,
+        '>', 27,
+        '{', 27,
+        '}', 27,
+      );
+      if (lookahead != 0) ADVANCE(289);
+      END_STATE();
+    case 288:
+      ACCEPT_TOKEN(aux_sym_attribute_value_token3);
+      if (lookahead == '-') ADVANCE(286);
+      if ((!eof && set_contains(aux_sym_attribute_value_token3_character_set_1, 10, lookahead))) ADVANCE(291);
+      END_STATE();
+    case 289:
+      ACCEPT_TOKEN(aux_sym_attribute_value_token3);
+      ADVANCE_MAP(
+        '-', 287,
+        '\n', 27,
+        '\r', 27,
+        ' ', 27,
+        '"', 27,
+        '\'', 27,
+        '/', 27,
+        '=', 27,
+        '>', 27,
+        '{', 27,
+        '}', 27,
+      );
+      if (lookahead != 0) ADVANCE(289);
+      END_STATE();
+    case 290:
+      ACCEPT_TOKEN(aux_sym_attribute_value_token3);
+      if (lookahead == '>') ADVANCE(320);
+      if ((!eof && set_contains(aux_sym_attribute_value_token3_character_set_1, 10, lookahead))) ADVANCE(291);
+      END_STATE();
+    case 291:
+      ACCEPT_TOKEN(aux_sym_attribute_value_token3);
+      if ((!eof && set_contains(aux_sym_attribute_value_token3_character_set_1, 10, lookahead))) ADVANCE(291);
+      END_STATE();
+    case 292:
       ACCEPT_TOKEN(aux_sym_text_token1);
       if (lookahead != 0 &&
           lookahead != '\n' &&
@@ -2351,136 +2377,139 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '-' &&
           lookahead != '<' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(286);
-      END_STATE();
-    case 287:
-      ACCEPT_TOKEN(anon_sym_LBRACE_DOLLAR);
-      END_STATE();
-    case 288:
-      ACCEPT_TOKEN(anon_sym_LBRACE_SLASH);
-      END_STATE();
-    case 289:
-      ACCEPT_TOKEN(aux_sym_end_brace_block_token1);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(289);
-      END_STATE();
-    case 290:
-      ACCEPT_TOKEN(anon_sym_if);
-      END_STATE();
-    case 291:
-      ACCEPT_TOKEN(anon_sym_for);
-      END_STATE();
-    case 292:
-      ACCEPT_TOKEN(anon_sym_try);
+          lookahead != '}') ADVANCE(292);
       END_STATE();
     case 293:
-      ACCEPT_TOKEN(anon_sym_await);
+      ACCEPT_TOKEN(anon_sym_LBRACE_DOLLAR);
       END_STATE();
     case 294:
-      ACCEPT_TOKEN(anon_sym_auth);
+      ACCEPT_TOKEN(anon_sym_LBRACE_SLASH);
       END_STATE();
     case 295:
-      ACCEPT_TOKEN(anon_sym_elif);
+      ACCEPT_TOKEN(aux_sym_end_brace_block_token1);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(295);
       END_STATE();
     case 296:
-      ACCEPT_TOKEN(anon_sym_else);
+      ACCEPT_TOKEN(anon_sym_if);
       END_STATE();
     case 297:
-      ACCEPT_TOKEN(anon_sym_finally);
+      ACCEPT_TOKEN(anon_sym_for);
       END_STATE();
     case 298:
-      ACCEPT_TOKEN(anon_sym_except);
+      ACCEPT_TOKEN(anon_sym_try);
       END_STATE();
     case 299:
-      ACCEPT_TOKEN(anon_sym_then);
+      ACCEPT_TOKEN(anon_sym_await);
       END_STATE();
     case 300:
-      ACCEPT_TOKEN(anon_sym_catch);
+      ACCEPT_TOKEN(anon_sym_auth);
       END_STATE();
     case 301:
-      ACCEPT_TOKEN(anon_sym_html);
+      ACCEPT_TOKEN(anon_sym_elif);
       END_STATE();
     case 302:
-      ACCEPT_TOKEN(anon_sym_snippet);
+      ACCEPT_TOKEN(anon_sym_else);
       END_STATE();
     case 303:
-      ACCEPT_TOKEN(anon_sym_render);
+      ACCEPT_TOKEN(anon_sym_finally);
       END_STATE();
     case 304:
-      ACCEPT_TOKEN(anon_sym_head);
+      ACCEPT_TOKEN(anon_sym_except);
       END_STATE();
     case 305:
-      ACCEPT_TOKEN(aux_sym__python_code_token1);
-      if (lookahead == '!') ADVANCE(308);
-      if (lookahead != 0 &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(312);
+      ACCEPT_TOKEN(anon_sym_then);
       END_STATE();
     case 306:
-      ACCEPT_TOKEN(aux_sym__python_code_token1);
-      if (lookahead == '-') ADVANCE(309);
-      if (lookahead != 0 &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(312);
+      ACCEPT_TOKEN(anon_sym_catch);
       END_STATE();
     case 307:
-      ACCEPT_TOKEN(aux_sym__python_code_token1);
-      if (lookahead == '-') ADVANCE(311);
-      if (lookahead == '{' ||
-          lookahead == '}') ADVANCE(27);
-      if (lookahead != 0) ADVANCE(309);
+      ACCEPT_TOKEN(anon_sym_html);
       END_STATE();
     case 308:
-      ACCEPT_TOKEN(aux_sym__python_code_token1);
-      if (lookahead == '-') ADVANCE(306);
-      if (lookahead != 0 &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(312);
+      ACCEPT_TOKEN(anon_sym_snippet);
       END_STATE();
     case 309:
-      ACCEPT_TOKEN(aux_sym__python_code_token1);
-      if (lookahead == '-') ADVANCE(307);
-      if (lookahead == '{' ||
-          lookahead == '}') ADVANCE(27);
-      if (lookahead != 0) ADVANCE(309);
+      ACCEPT_TOKEN(anon_sym_render);
       END_STATE();
     case 310:
-      ACCEPT_TOKEN(aux_sym__python_code_token1);
-      if (lookahead == '<') ADVANCE(305);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(310);
-      if (lookahead != 0 &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(312);
+      ACCEPT_TOKEN(anon_sym_head);
       END_STATE();
     case 311:
-      ACCEPT_TOKEN(aux_sym__python_code_token1);
-      if (lookahead == '>') ADVANCE(312);
-      if (lookahead != 0 &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(312);
+      ACCEPT_TOKEN(anon_sym_dynamic);
       END_STATE();
     case 312:
       ACCEPT_TOKEN(aux_sym__python_code_token1);
+      if (lookahead == '!') ADVANCE(315);
       if (lookahead != 0 &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(312);
+          lookahead != '}') ADVANCE(319);
       END_STATE();
     case 313:
-      ACCEPT_TOKEN(sym_comment);
+      ACCEPT_TOKEN(aux_sym__python_code_token1);
+      if (lookahead == '-') ADVANCE(316);
+      if (lookahead != 0 &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(319);
       END_STATE();
     case 314:
-      ACCEPT_TOKEN(sym_hyphen);
+      ACCEPT_TOKEN(aux_sym__python_code_token1);
+      if (lookahead == '-') ADVANCE(318);
+      if (lookahead == '{' ||
+          lookahead == '}') ADVANCE(27);
+      if (lookahead != 0) ADVANCE(316);
       END_STATE();
     case 315:
+      ACCEPT_TOKEN(aux_sym__python_code_token1);
+      if (lookahead == '-') ADVANCE(313);
+      if (lookahead != 0 &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(319);
+      END_STATE();
+    case 316:
+      ACCEPT_TOKEN(aux_sym__python_code_token1);
+      if (lookahead == '-') ADVANCE(314);
+      if (lookahead == '{' ||
+          lookahead == '}') ADVANCE(27);
+      if (lookahead != 0) ADVANCE(316);
+      END_STATE();
+    case 317:
+      ACCEPT_TOKEN(aux_sym__python_code_token1);
+      if (lookahead == '<') ADVANCE(312);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(317);
+      if (lookahead != 0 &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(319);
+      END_STATE();
+    case 318:
+      ACCEPT_TOKEN(aux_sym__python_code_token1);
+      if (lookahead == '>') ADVANCE(319);
+      if (lookahead != 0 &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(319);
+      END_STATE();
+    case 319:
+      ACCEPT_TOKEN(aux_sym__python_code_token1);
+      if (lookahead != 0 &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(319);
+      END_STATE();
+    case 320:
+      ACCEPT_TOKEN(sym_comment);
+      END_STATE();
+    case 321:
+      ACCEPT_TOKEN(sym_hyphen);
+      END_STATE();
+    case 322:
       ACCEPT_TOKEN(sym_hyphen);
       if (lookahead == '-') ADVANCE(22);
       END_STATE();
-    case 316:
+    case 323:
       ACCEPT_TOKEN(sym_bang);
       END_STATE();
-    case 317:
+    case 324:
       ACCEPT_TOKEN(sym_bang);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
@@ -2493,12 +2522,12 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
 
 static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0, .external_lex_state = 1},
-  [1] = {.lex_state = 139, .external_lex_state = 1},
-  [2] = {.lex_state = 140, .external_lex_state = 1},
-  [3] = {.lex_state = 141},
-  [4] = {.lex_state = 141},
-  [5] = {.lex_state = 141},
-  [6] = {.lex_state = 141},
+  [1] = {.lex_state = 145, .external_lex_state = 1},
+  [2] = {.lex_state = 146, .external_lex_state = 1},
+  [3] = {.lex_state = 147},
+  [4] = {.lex_state = 147},
+  [5] = {.lex_state = 147},
+  [6] = {.lex_state = 147},
   [7] = {.lex_state = 19},
   [8] = {.lex_state = 19},
   [9] = {.lex_state = 19},
@@ -2510,33 +2539,33 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [15] = {.lex_state = 19},
   [16] = {.lex_state = 0},
   [17] = {.lex_state = 0},
-  [18] = {.lex_state = 139, .external_lex_state = 1},
+  [18] = {.lex_state = 145, .external_lex_state = 1},
   [19] = {.lex_state = 1},
-  [20] = {.lex_state = 139, .external_lex_state = 1},
+  [20] = {.lex_state = 145, .external_lex_state = 1},
   [21] = {.lex_state = 1},
-  [22] = {.lex_state = 141},
-  [23] = {.lex_state = 141},
-  [24] = {.lex_state = 141},
-  [25] = {.lex_state = 141},
-  [26] = {.lex_state = 141},
-  [27] = {.lex_state = 141},
-  [28] = {.lex_state = 141},
-  [29] = {.lex_state = 141},
-  [30] = {.lex_state = 141},
-  [31] = {.lex_state = 141},
-  [32] = {.lex_state = 141},
-  [33] = {.lex_state = 141},
-  [34] = {.lex_state = 141},
-  [35] = {.lex_state = 141},
-  [36] = {.lex_state = 141},
-  [37] = {.lex_state = 141},
-  [38] = {.lex_state = 141},
-  [39] = {.lex_state = 141},
-  [40] = {.lex_state = 141},
-  [41] = {.lex_state = 141},
+  [22] = {.lex_state = 147},
+  [23] = {.lex_state = 147},
+  [24] = {.lex_state = 147},
+  [25] = {.lex_state = 147},
+  [26] = {.lex_state = 147},
+  [27] = {.lex_state = 147},
+  [28] = {.lex_state = 147},
+  [29] = {.lex_state = 147},
+  [30] = {.lex_state = 147},
+  [31] = {.lex_state = 147},
+  [32] = {.lex_state = 147},
+  [33] = {.lex_state = 147},
+  [34] = {.lex_state = 147},
+  [35] = {.lex_state = 147},
+  [36] = {.lex_state = 147},
+  [37] = {.lex_state = 147},
+  [38] = {.lex_state = 147},
+  [39] = {.lex_state = 147},
+  [40] = {.lex_state = 147},
+  [41] = {.lex_state = 147},
   [42] = {.lex_state = 19},
   [43] = {.lex_state = 19},
-  [44] = {.lex_state = 141},
+  [44] = {.lex_state = 147},
   [45] = {.lex_state = 19},
   [46] = {.lex_state = 19},
   [47] = {.lex_state = 19},
@@ -2555,7 +2584,7 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [60] = {.lex_state = 19},
   [61] = {.lex_state = 19},
   [62] = {.lex_state = 19},
-  [63] = {.lex_state = 141},
+  [63] = {.lex_state = 147},
   [64] = {.lex_state = 2},
   [65] = {.lex_state = 2},
   [66] = {.lex_state = 2},
@@ -2626,9 +2655,9 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [131] = {.lex_state = 5},
   [132] = {.lex_state = 5},
   [133] = {.lex_state = 0},
-  [134] = {.lex_state = 266},
+  [134] = {.lex_state = 272},
   [135] = {.lex_state = 0},
-  [136] = {.lex_state = 275},
+  [136] = {.lex_state = 281},
   [137] = {.lex_state = 0},
   [138] = {.lex_state = 0},
   [139] = {.lex_state = 0},
@@ -2701,6 +2730,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_snippet] = ACTIONS(1),
     [anon_sym_render] = ACTIONS(1),
     [anon_sym_head] = ACTIONS(1),
+    [anon_sym_dynamic] = ACTIONS(1),
     [sym_comment] = ACTIONS(3),
     [sym_hyphen] = ACTIONS(1),
     [sym_bang] = ACTIONS(1),
@@ -3247,7 +3277,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_comment,
     STATE(98), 1,
       sym_block_keyword,
-    ACTIONS(125), 15,
+    ACTIONS(125), 16,
       anon_sym_if,
       anon_sym_for,
       anon_sym_try,
@@ -3263,12 +3293,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_snippet,
       anon_sym_render,
       anon_sym_head,
-  [685] = 3,
+      anon_sym_dynamic,
+  [686] = 3,
     ACTIONS(3), 1,
       sym_comment,
     STATE(118), 1,
       sym_block_keyword,
-    ACTIONS(125), 15,
+    ACTIONS(125), 16,
       anon_sym_if,
       anon_sym_for,
       anon_sym_try,
@@ -3284,7 +3315,8 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_snippet,
       anon_sym_render,
       anon_sym_head,
-  [709] = 6,
+      anon_sym_dynamic,
+  [711] = 6,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(129), 1,
@@ -3307,7 +3339,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_text_token1,
       anon_sym_LBRACE_DOLLAR,
       anon_sym_LBRACE_SLASH,
-  [738] = 3,
+  [740] = 3,
     ACTIONS(137), 1,
       sym_tag_name,
     ACTIONS(139), 1,
@@ -3327,7 +3359,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_source,
       anon_sym_track,
       anon_sym_wbr,
-  [761] = 6,
+  [763] = 6,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(143), 1,
@@ -3350,7 +3382,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_text_token1,
       anon_sym_LBRACE_DOLLAR,
       anon_sym_LBRACE_SLASH,
-  [790] = 3,
+  [792] = 3,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(153), 1,
@@ -3370,7 +3402,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_source,
       anon_sym_track,
       anon_sym_wbr,
-  [813] = 3,
+  [815] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(157), 2,
@@ -3386,7 +3418,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_SLASH,
       sym_hyphen,
       sym_bang,
-  [832] = 3,
+  [834] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(161), 2,
@@ -3402,7 +3434,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_SLASH,
       sym_hyphen,
       sym_bang,
-  [851] = 3,
+  [853] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(165), 2,
@@ -3418,7 +3450,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_SLASH,
       sym_hyphen,
       sym_bang,
-  [870] = 3,
+  [872] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(169), 2,
@@ -3434,7 +3466,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_SLASH,
       sym_hyphen,
       sym_bang,
-  [889] = 3,
+  [891] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(173), 2,
@@ -3450,7 +3482,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_SLASH,
       sym_hyphen,
       sym_bang,
-  [908] = 3,
+  [910] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(177), 2,
@@ -3466,7 +3498,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_SLASH,
       sym_hyphen,
       sym_bang,
-  [927] = 3,
+  [929] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(181), 2,
@@ -3482,7 +3514,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_SLASH,
       sym_hyphen,
       sym_bang,
-  [946] = 3,
+  [948] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(185), 2,
@@ -3498,7 +3530,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_SLASH,
       sym_hyphen,
       sym_bang,
-  [965] = 3,
+  [967] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(189), 2,
@@ -3514,7 +3546,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_SLASH,
       sym_hyphen,
       sym_bang,
-  [984] = 3,
+  [986] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(193), 2,
@@ -3530,7 +3562,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_SLASH,
       sym_hyphen,
       sym_bang,
-  [1003] = 3,
+  [1005] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(197), 2,
@@ -3546,7 +3578,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_SLASH,
       sym_hyphen,
       sym_bang,
-  [1022] = 3,
+  [1024] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(201), 2,
@@ -3562,7 +3594,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_SLASH,
       sym_hyphen,
       sym_bang,
-  [1041] = 3,
+  [1043] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(205), 2,
@@ -3578,7 +3610,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_SLASH,
       sym_hyphen,
       sym_bang,
-  [1060] = 3,
+  [1062] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(209), 2,
@@ -3594,7 +3626,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_SLASH,
       sym_hyphen,
       sym_bang,
-  [1079] = 3,
+  [1081] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(213), 2,
@@ -3610,7 +3642,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_SLASH,
       sym_hyphen,
       sym_bang,
-  [1098] = 3,
+  [1100] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(217), 2,
@@ -3626,7 +3658,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_SLASH,
       sym_hyphen,
       sym_bang,
-  [1117] = 3,
+  [1119] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(221), 2,
@@ -3642,7 +3674,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_SLASH,
       sym_hyphen,
       sym_bang,
-  [1136] = 3,
+  [1138] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(225), 2,
@@ -3658,7 +3690,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_SLASH,
       sym_hyphen,
       sym_bang,
-  [1155] = 3,
+  [1157] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(229), 2,
@@ -3674,7 +3706,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_SLASH,
       sym_hyphen,
       sym_bang,
-  [1174] = 3,
+  [1176] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(233), 2,
@@ -3690,7 +3722,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_SLASH,
       sym_hyphen,
       sym_bang,
-  [1193] = 3,
+  [1195] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(237), 2,
@@ -3706,7 +3738,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_SLASH,
       sym_hyphen,
       sym_bang,
-  [1212] = 3,
+  [1214] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(217), 2,
@@ -3722,7 +3754,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_SLASH,
       sym_hyphen,
       sym_bang,
-  [1231] = 3,
+  [1233] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(241), 2,
@@ -3738,7 +3770,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_SLASH,
       sym_hyphen,
       sym_bang,
-  [1250] = 3,
+  [1252] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(165), 2,
@@ -3754,7 +3786,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_SLASH,
       sym_hyphen,
       sym_bang,
-  [1269] = 3,
+  [1271] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(169), 2,
@@ -3770,7 +3802,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_SLASH,
       sym_hyphen,
       sym_bang,
-  [1288] = 3,
+  [1290] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(173), 2,
@@ -3786,7 +3818,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_SLASH,
       sym_hyphen,
       sym_bang,
-  [1307] = 3,
+  [1309] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(177), 2,
@@ -3802,7 +3834,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_SLASH,
       sym_hyphen,
       sym_bang,
-  [1326] = 3,
+  [1328] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(181), 2,
@@ -3818,7 +3850,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_SLASH,
       sym_hyphen,
       sym_bang,
-  [1345] = 3,
+  [1347] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(185), 2,
@@ -3834,7 +3866,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_SLASH,
       sym_hyphen,
       sym_bang,
-  [1364] = 3,
+  [1366] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(189), 2,
@@ -3850,7 +3882,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_SLASH,
       sym_hyphen,
       sym_bang,
-  [1383] = 3,
+  [1385] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(193), 2,
@@ -3866,7 +3898,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_SLASH,
       sym_hyphen,
       sym_bang,
-  [1402] = 3,
+  [1404] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(197), 2,
@@ -3882,7 +3914,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_SLASH,
       sym_hyphen,
       sym_bang,
-  [1421] = 3,
+  [1423] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(201), 2,
@@ -3898,7 +3930,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_SLASH,
       sym_hyphen,
       sym_bang,
-  [1440] = 3,
+  [1442] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(157), 2,
@@ -3914,7 +3946,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_SLASH,
       sym_hyphen,
       sym_bang,
-  [1459] = 3,
+  [1461] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(205), 2,
@@ -3930,7 +3962,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_SLASH,
       sym_hyphen,
       sym_bang,
-  [1478] = 3,
+  [1480] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(209), 2,
@@ -3946,7 +3978,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_SLASH,
       sym_hyphen,
       sym_bang,
-  [1497] = 3,
+  [1499] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(213), 2,
@@ -3962,7 +3994,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_SLASH,
       sym_hyphen,
       sym_bang,
-  [1516] = 3,
+  [1518] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(221), 2,
@@ -3978,7 +4010,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_SLASH,
       sym_hyphen,
       sym_bang,
-  [1535] = 3,
+  [1537] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(225), 2,
@@ -3994,7 +4026,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_SLASH,
       sym_hyphen,
       sym_bang,
-  [1554] = 3,
+  [1556] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(229), 2,
@@ -4010,7 +4042,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_SLASH,
       sym_hyphen,
       sym_bang,
-  [1573] = 3,
+  [1575] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(233), 2,
@@ -4026,7 +4058,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_SLASH,
       sym_hyphen,
       sym_bang,
-  [1592] = 3,
+  [1594] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(237), 2,
@@ -4042,7 +4074,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_SLASH,
       sym_hyphen,
       sym_bang,
-  [1611] = 6,
+  [1613] = 6,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(245), 1,
@@ -4059,7 +4091,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(83), 2,
       sym_attribute_shorthand,
       sym_spread_shorthand,
-  [1634] = 6,
+  [1636] = 6,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(251), 1,
@@ -4076,7 +4108,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(83), 2,
       sym_attribute_shorthand,
       sym_spread_shorthand,
-  [1657] = 7,
+  [1659] = 7,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(245), 1,
@@ -4094,7 +4126,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(83), 2,
       sym_attribute_shorthand,
       sym_spread_shorthand,
-  [1682] = 6,
+  [1684] = 6,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(245), 1,
@@ -4111,7 +4143,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(83), 2,
       sym_attribute_shorthand,
       sym_spread_shorthand,
-  [1705] = 7,
+  [1707] = 7,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(245), 1,
@@ -4129,7 +4161,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(83), 2,
       sym_attribute_shorthand,
       sym_spread_shorthand,
-  [1730] = 6,
+  [1732] = 6,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(245), 1,
@@ -4146,7 +4178,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(83), 2,
       sym_attribute_shorthand,
       sym_spread_shorthand,
-  [1753] = 7,
+  [1755] = 7,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(245), 1,
@@ -4164,7 +4196,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(83), 2,
       sym_attribute_shorthand,
       sym_spread_shorthand,
-  [1778] = 6,
+  [1780] = 6,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(245), 1,
@@ -4181,7 +4213,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(83), 2,
       sym_attribute_shorthand,
       sym_spread_shorthand,
-  [1801] = 7,
+  [1803] = 7,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(245), 1,
@@ -4199,7 +4231,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(83), 2,
       sym_attribute_shorthand,
       sym_spread_shorthand,
-  [1826] = 6,
+  [1828] = 6,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(245), 1,
@@ -4215,7 +4247,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(83), 2,
       sym_attribute_shorthand,
       sym_spread_shorthand,
-  [1848] = 6,
+  [1850] = 6,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(245), 1,
@@ -4231,7 +4263,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(83), 2,
       sym_attribute_shorthand,
       sym_spread_shorthand,
-  [1870] = 6,
+  [1872] = 6,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(245), 1,
@@ -4247,7 +4279,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(83), 2,
       sym_attribute_shorthand,
       sym_spread_shorthand,
-  [1892] = 6,
+  [1894] = 6,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(245), 1,
@@ -4263,7 +4295,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(83), 2,
       sym_attribute_shorthand,
       sym_spread_shorthand,
-  [1914] = 6,
+  [1916] = 6,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(245), 1,
@@ -4279,7 +4311,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(83), 2,
       sym_attribute_shorthand,
       sym_spread_shorthand,
-  [1936] = 6,
+  [1938] = 6,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(245), 1,
@@ -4295,7 +4327,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(83), 2,
       sym_attribute_shorthand,
       sym_spread_shorthand,
-  [1958] = 6,
+  [1960] = 6,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(245), 1,
@@ -4311,7 +4343,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(83), 2,
       sym_attribute_shorthand,
       sym_spread_shorthand,
-  [1980] = 6,
+  [1982] = 6,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(245), 1,
@@ -4327,7 +4359,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(83), 2,
       sym_attribute_shorthand,
       sym_spread_shorthand,
-  [2002] = 6,
+  [2004] = 6,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(295), 1,
@@ -4341,7 +4373,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(84), 2,
       sym_attribute_value,
       sym_interpolation,
-  [2022] = 3,
+  [2024] = 3,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(305), 1,
@@ -4352,7 +4384,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE,
       sym_attribute_name,
       sym_special_attribute_name,
-  [2036] = 2,
+  [2038] = 2,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(307), 5,
@@ -4361,7 +4393,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE,
       sym_attribute_name,
       sym_special_attribute_name,
-  [2047] = 2,
+  [2049] = 2,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(309), 5,
@@ -4370,7 +4402,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE,
       sym_attribute_name,
       sym_special_attribute_name,
-  [2058] = 2,
+  [2060] = 2,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(311), 5,
@@ -4379,7 +4411,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE,
       sym_attribute_name,
       sym_special_attribute_name,
-  [2069] = 2,
+  [2071] = 2,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(313), 5,
@@ -4388,7 +4420,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE,
       sym_attribute_name,
       sym_special_attribute_name,
-  [2080] = 2,
+  [2082] = 2,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(315), 5,
@@ -4397,7 +4429,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE,
       sym_attribute_name,
       sym_special_attribute_name,
-  [2091] = 2,
+  [2093] = 2,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(181), 5,
@@ -4406,7 +4438,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE,
       sym_attribute_name,
       sym_special_attribute_name,
-  [2102] = 2,
+  [2104] = 2,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(317), 5,
@@ -4415,7 +4447,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE,
       sym_attribute_name,
       sym_special_attribute_name,
-  [2113] = 5,
+  [2115] = 5,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(319), 1,
@@ -4426,7 +4458,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym__python_code_token1,
     STATE(93), 1,
       aux_sym__python_code,
-  [2129] = 5,
+  [2131] = 5,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(325), 1,
@@ -4437,7 +4469,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym__script_content_token1,
     STATE(116), 1,
       aux_sym__style_content,
-  [2145] = 5,
+  [2147] = 5,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(319), 1,
@@ -4448,7 +4480,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RBRACE,
     STATE(93), 1,
       aux_sym__python_code,
-  [2161] = 5,
+  [2163] = 5,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(333), 1,
@@ -4459,7 +4491,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym__python_code_token1,
     STATE(93), 1,
       aux_sym__python_code,
-  [2177] = 5,
+  [2179] = 5,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(325), 1,
@@ -4470,7 +4502,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT_SLASHstyle_GT,
     STATE(105), 1,
       aux_sym__style_content,
-  [2193] = 5,
+  [2195] = 5,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(319), 1,
@@ -4481,7 +4513,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RBRACE,
     STATE(93), 1,
       aux_sym__python_code,
-  [2209] = 5,
+  [2211] = 5,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(319), 1,
@@ -4492,7 +4524,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RBRACE,
     STATE(92), 1,
       aux_sym__python_code,
-  [2225] = 5,
+  [2227] = 5,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(319), 1,
@@ -4503,7 +4535,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RBRACE,
     STATE(93), 1,
       aux_sym__python_code,
-  [2241] = 5,
+  [2243] = 5,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(319), 1,
@@ -4514,7 +4546,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RBRACE,
     STATE(95), 1,
       aux_sym__python_code,
-  [2257] = 5,
+  [2259] = 5,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(351), 1,
@@ -4525,7 +4557,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym__script_content_token1,
     STATE(99), 1,
       aux_sym__script_content,
-  [2273] = 5,
+  [2275] = 5,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(359), 1,
@@ -4536,7 +4568,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym__script_content_token1,
     STATE(99), 1,
       aux_sym__script_content,
-  [2289] = 5,
+  [2291] = 5,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(359), 1,
@@ -4547,7 +4579,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT_SLASHscript_GT,
     STATE(114), 1,
       aux_sym__script_content,
-  [2305] = 5,
+  [2307] = 5,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(359), 1,
@@ -4558,7 +4590,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT_SLASHscript_GT,
     STATE(106), 1,
       aux_sym__script_content,
-  [2321] = 5,
+  [2323] = 5,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(325), 1,
@@ -4569,7 +4601,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT_SLASHstyle_GT,
     STATE(108), 1,
       aux_sym__style_content,
-  [2337] = 5,
+  [2339] = 5,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(319), 1,
@@ -4580,7 +4612,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RBRACE,
     STATE(93), 1,
       aux_sym__python_code,
-  [2353] = 5,
+  [2355] = 5,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(325), 1,
@@ -4591,7 +4623,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT_SLASHstyle_GT,
     STATE(115), 1,
       aux_sym__style_content,
-  [2369] = 5,
+  [2371] = 5,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(359), 1,
@@ -4602,7 +4634,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT_SLASHscript_GT,
     STATE(99), 1,
       aux_sym__script_content,
-  [2385] = 5,
+  [2387] = 5,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(359), 1,
@@ -4613,7 +4645,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT_SLASHscript_GT,
     STATE(111), 1,
       aux_sym__script_content,
-  [2401] = 5,
+  [2403] = 5,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(325), 1,
@@ -4624,7 +4656,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT_SLASHstyle_GT,
     STATE(115), 1,
       aux_sym__style_content,
-  [2417] = 5,
+  [2419] = 5,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(325), 1,
@@ -4635,7 +4667,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT_SLASHstyle_GT,
     STATE(112), 1,
       aux_sym__style_content,
-  [2433] = 5,
+  [2435] = 5,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(319), 1,
@@ -4646,7 +4678,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RBRACE,
     STATE(93), 1,
       aux_sym__python_code,
-  [2449] = 5,
+  [2451] = 5,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(359), 1,
@@ -4657,7 +4689,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT_SLASHscript_GT,
     STATE(99), 1,
       aux_sym__script_content,
-  [2465] = 5,
+  [2467] = 5,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(325), 1,
@@ -4668,7 +4700,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT_SLASHstyle_GT,
     STATE(115), 1,
       aux_sym__style_content,
-  [2481] = 5,
+  [2483] = 5,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(319), 1,
@@ -4679,7 +4711,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RBRACE,
     STATE(93), 1,
       aux_sym__python_code,
-  [2497] = 5,
+  [2499] = 5,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(359), 1,
@@ -4690,7 +4722,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT_SLASHscript_GT,
     STATE(99), 1,
       aux_sym__script_content,
-  [2513] = 5,
+  [2515] = 5,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(393), 1,
@@ -4701,7 +4733,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym__script_content_token1,
     STATE(115), 1,
       aux_sym__style_content,
-  [2529] = 5,
+  [2531] = 5,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(325), 1,
@@ -4712,7 +4744,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT_SLASHstyle_GT,
     STATE(115), 1,
       aux_sym__style_content,
-  [2545] = 5,
+  [2547] = 5,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(359), 1,
@@ -4723,7 +4755,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT_SLASHscript_GT,
     STATE(100), 1,
       aux_sym__script_content,
-  [2561] = 5,
+  [2563] = 5,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(319), 1,
@@ -4734,14 +4766,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RBRACE,
     STATE(110), 1,
       aux_sym__python_code,
-  [2577] = 2,
+  [2579] = 2,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(336), 3,
       anon_sym_LBRACE,
       anon_sym_RBRACE,
       aux_sym__python_code_token1,
-  [2586] = 4,
+  [2588] = 4,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(319), 1,
@@ -4750,7 +4782,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym__python_code_token1,
     STATE(97), 1,
       aux_sym__python_code,
-  [2599] = 3,
+  [2601] = 3,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(409), 1,
@@ -4758,7 +4790,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(407), 2,
       anon_sym_LT,
       anon_sym_LT_SLASHstyle_GT,
-  [2610] = 4,
+  [2612] = 4,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(319), 1,
@@ -4767,7 +4799,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym__python_code_token1,
     STATE(113), 1,
       aux_sym__python_code,
-  [2623] = 3,
+  [2625] = 3,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(413), 1,
@@ -4775,7 +4807,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(411), 2,
       anon_sym_LT,
       anon_sym_LT_SLASHscript_GT,
-  [2634] = 4,
+  [2636] = 4,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(319), 1,
@@ -4784,28 +4816,28 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym__python_code_token1,
     STATE(104), 1,
       aux_sym__python_code,
-  [2647] = 2,
+  [2649] = 2,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(415), 3,
       anon_sym_LBRACE,
       anon_sym_RBRACE,
       aux_sym__python_code_token1,
-  [2656] = 2,
+  [2658] = 2,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(417), 3,
       anon_sym_LBRACE,
       anon_sym_RBRACE,
       aux_sym__python_code_token1,
-  [2665] = 2,
+  [2667] = 2,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(419), 3,
       anon_sym_LBRACE,
       anon_sym_RBRACE,
       aux_sym__python_code_token1,
-  [2674] = 4,
+  [2676] = 4,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(319), 1,
@@ -4814,146 +4846,146 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym__python_code_token1,
     STATE(90), 1,
       aux_sym__python_code,
-  [2687] = 3,
+  [2689] = 3,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(421), 1,
       sym_separator,
     ACTIONS(423), 1,
       sym__python_content,
-  [2697] = 3,
+  [2699] = 3,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(425), 1,
       anon_sym_STAR_STAR,
     ACTIONS(427), 1,
       sym_attribute_name,
-  [2707] = 2,
+  [2709] = 2,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(429), 1,
       sym_tag_name,
-  [2714] = 2,
+  [2716] = 2,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(431), 1,
       sym_tag_name,
-  [2721] = 2,
+  [2723] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(433), 1,
       anon_sym_GT,
-  [2728] = 2,
+  [2730] = 2,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(435), 1,
       aux_sym_attribute_value_token1,
-  [2735] = 2,
+  [2737] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(437), 1,
       anon_sym_DQUOTE,
-  [2742] = 2,
+  [2744] = 2,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(439), 1,
       aux_sym_attribute_value_token2,
-  [2749] = 2,
+  [2751] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(441), 1,
       anon_sym_GT,
-  [2756] = 2,
+  [2758] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(443), 1,
       anon_sym_GT,
-  [2763] = 2,
+  [2765] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(445), 1,
       anon_sym_GT,
-  [2770] = 2,
+  [2772] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(447), 1,
       aux_sym_end_brace_block_token1,
-  [2777] = 2,
+  [2779] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(449), 1,
       sym_separator,
-  [2784] = 2,
+  [2786] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(451), 1,
       ts_builtin_sym_end,
-  [2791] = 2,
+  [2793] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(437), 1,
       anon_sym_SQUOTE,
-  [2798] = 2,
+  [2800] = 2,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(453), 1,
       sym_tag_name,
-  [2805] = 2,
+  [2807] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(455), 1,
       anon_sym_GT,
-  [2812] = 2,
+  [2814] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(457), 1,
       aux_sym_end_brace_block_token1,
-  [2819] = 2,
+  [2821] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(459), 1,
       anon_sym_RBRACE,
-  [2826] = 2,
+  [2828] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(461), 1,
       anon_sym_RBRACE,
-  [2833] = 2,
+  [2835] = 2,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(463), 1,
       sym_tag_name,
-  [2840] = 2,
+  [2842] = 2,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(465), 1,
       sym_tag_name,
-  [2847] = 2,
+  [2849] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(467), 1,
       anon_sym_GT,
-  [2854] = 2,
+  [2856] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(31), 1,
       ts_builtin_sym_end,
-  [2861] = 2,
+  [2863] = 2,
     ACTIONS(139), 1,
       sym_comment,
     ACTIONS(469), 1,
       sym_tag_name,
-  [2868] = 2,
+  [2870] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(471), 1,
       anon_sym_RBRACE,
-  [2875] = 2,
+  [2877] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(473), 1,
       ts_builtin_sym_end,
-  [2882] = 2,
+  [2884] = 2,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(33), 1,
@@ -4976,146 +5008,146 @@ static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(14)] = 569,
   [SMALL_STATE(15)] = 615,
   [SMALL_STATE(16)] = 661,
-  [SMALL_STATE(17)] = 685,
-  [SMALL_STATE(18)] = 709,
-  [SMALL_STATE(19)] = 738,
-  [SMALL_STATE(20)] = 761,
-  [SMALL_STATE(21)] = 790,
-  [SMALL_STATE(22)] = 813,
-  [SMALL_STATE(23)] = 832,
-  [SMALL_STATE(24)] = 851,
-  [SMALL_STATE(25)] = 870,
-  [SMALL_STATE(26)] = 889,
-  [SMALL_STATE(27)] = 908,
-  [SMALL_STATE(28)] = 927,
-  [SMALL_STATE(29)] = 946,
-  [SMALL_STATE(30)] = 965,
-  [SMALL_STATE(31)] = 984,
-  [SMALL_STATE(32)] = 1003,
-  [SMALL_STATE(33)] = 1022,
-  [SMALL_STATE(34)] = 1041,
-  [SMALL_STATE(35)] = 1060,
-  [SMALL_STATE(36)] = 1079,
-  [SMALL_STATE(37)] = 1098,
-  [SMALL_STATE(38)] = 1117,
-  [SMALL_STATE(39)] = 1136,
-  [SMALL_STATE(40)] = 1155,
-  [SMALL_STATE(41)] = 1174,
-  [SMALL_STATE(42)] = 1193,
-  [SMALL_STATE(43)] = 1212,
-  [SMALL_STATE(44)] = 1231,
-  [SMALL_STATE(45)] = 1250,
-  [SMALL_STATE(46)] = 1269,
-  [SMALL_STATE(47)] = 1288,
-  [SMALL_STATE(48)] = 1307,
-  [SMALL_STATE(49)] = 1326,
-  [SMALL_STATE(50)] = 1345,
-  [SMALL_STATE(51)] = 1364,
-  [SMALL_STATE(52)] = 1383,
-  [SMALL_STATE(53)] = 1402,
-  [SMALL_STATE(54)] = 1421,
-  [SMALL_STATE(55)] = 1440,
-  [SMALL_STATE(56)] = 1459,
-  [SMALL_STATE(57)] = 1478,
-  [SMALL_STATE(58)] = 1497,
-  [SMALL_STATE(59)] = 1516,
-  [SMALL_STATE(60)] = 1535,
-  [SMALL_STATE(61)] = 1554,
-  [SMALL_STATE(62)] = 1573,
-  [SMALL_STATE(63)] = 1592,
-  [SMALL_STATE(64)] = 1611,
-  [SMALL_STATE(65)] = 1634,
-  [SMALL_STATE(66)] = 1657,
-  [SMALL_STATE(67)] = 1682,
-  [SMALL_STATE(68)] = 1705,
-  [SMALL_STATE(69)] = 1730,
-  [SMALL_STATE(70)] = 1753,
-  [SMALL_STATE(71)] = 1778,
-  [SMALL_STATE(72)] = 1801,
-  [SMALL_STATE(73)] = 1826,
-  [SMALL_STATE(74)] = 1848,
-  [SMALL_STATE(75)] = 1870,
-  [SMALL_STATE(76)] = 1892,
-  [SMALL_STATE(77)] = 1914,
-  [SMALL_STATE(78)] = 1936,
-  [SMALL_STATE(79)] = 1958,
-  [SMALL_STATE(80)] = 1980,
-  [SMALL_STATE(81)] = 2002,
-  [SMALL_STATE(82)] = 2022,
-  [SMALL_STATE(83)] = 2036,
-  [SMALL_STATE(84)] = 2047,
-  [SMALL_STATE(85)] = 2058,
-  [SMALL_STATE(86)] = 2069,
-  [SMALL_STATE(87)] = 2080,
-  [SMALL_STATE(88)] = 2091,
-  [SMALL_STATE(89)] = 2102,
-  [SMALL_STATE(90)] = 2113,
-  [SMALL_STATE(91)] = 2129,
-  [SMALL_STATE(92)] = 2145,
-  [SMALL_STATE(93)] = 2161,
-  [SMALL_STATE(94)] = 2177,
-  [SMALL_STATE(95)] = 2193,
-  [SMALL_STATE(96)] = 2209,
-  [SMALL_STATE(97)] = 2225,
-  [SMALL_STATE(98)] = 2241,
-  [SMALL_STATE(99)] = 2257,
-  [SMALL_STATE(100)] = 2273,
-  [SMALL_STATE(101)] = 2289,
-  [SMALL_STATE(102)] = 2305,
-  [SMALL_STATE(103)] = 2321,
-  [SMALL_STATE(104)] = 2337,
-  [SMALL_STATE(105)] = 2353,
-  [SMALL_STATE(106)] = 2369,
-  [SMALL_STATE(107)] = 2385,
-  [SMALL_STATE(108)] = 2401,
-  [SMALL_STATE(109)] = 2417,
-  [SMALL_STATE(110)] = 2433,
-  [SMALL_STATE(111)] = 2449,
-  [SMALL_STATE(112)] = 2465,
-  [SMALL_STATE(113)] = 2481,
-  [SMALL_STATE(114)] = 2497,
-  [SMALL_STATE(115)] = 2513,
-  [SMALL_STATE(116)] = 2529,
-  [SMALL_STATE(117)] = 2545,
-  [SMALL_STATE(118)] = 2561,
-  [SMALL_STATE(119)] = 2577,
-  [SMALL_STATE(120)] = 2586,
-  [SMALL_STATE(121)] = 2599,
-  [SMALL_STATE(122)] = 2610,
-  [SMALL_STATE(123)] = 2623,
-  [SMALL_STATE(124)] = 2634,
-  [SMALL_STATE(125)] = 2647,
-  [SMALL_STATE(126)] = 2656,
-  [SMALL_STATE(127)] = 2665,
-  [SMALL_STATE(128)] = 2674,
-  [SMALL_STATE(129)] = 2687,
-  [SMALL_STATE(130)] = 2697,
-  [SMALL_STATE(131)] = 2707,
-  [SMALL_STATE(132)] = 2714,
-  [SMALL_STATE(133)] = 2721,
-  [SMALL_STATE(134)] = 2728,
-  [SMALL_STATE(135)] = 2735,
-  [SMALL_STATE(136)] = 2742,
-  [SMALL_STATE(137)] = 2749,
-  [SMALL_STATE(138)] = 2756,
-  [SMALL_STATE(139)] = 2763,
-  [SMALL_STATE(140)] = 2770,
-  [SMALL_STATE(141)] = 2777,
-  [SMALL_STATE(142)] = 2784,
-  [SMALL_STATE(143)] = 2791,
-  [SMALL_STATE(144)] = 2798,
-  [SMALL_STATE(145)] = 2805,
-  [SMALL_STATE(146)] = 2812,
-  [SMALL_STATE(147)] = 2819,
-  [SMALL_STATE(148)] = 2826,
-  [SMALL_STATE(149)] = 2833,
-  [SMALL_STATE(150)] = 2840,
-  [SMALL_STATE(151)] = 2847,
-  [SMALL_STATE(152)] = 2854,
-  [SMALL_STATE(153)] = 2861,
-  [SMALL_STATE(154)] = 2868,
-  [SMALL_STATE(155)] = 2875,
-  [SMALL_STATE(156)] = 2882,
+  [SMALL_STATE(17)] = 686,
+  [SMALL_STATE(18)] = 711,
+  [SMALL_STATE(19)] = 740,
+  [SMALL_STATE(20)] = 763,
+  [SMALL_STATE(21)] = 792,
+  [SMALL_STATE(22)] = 815,
+  [SMALL_STATE(23)] = 834,
+  [SMALL_STATE(24)] = 853,
+  [SMALL_STATE(25)] = 872,
+  [SMALL_STATE(26)] = 891,
+  [SMALL_STATE(27)] = 910,
+  [SMALL_STATE(28)] = 929,
+  [SMALL_STATE(29)] = 948,
+  [SMALL_STATE(30)] = 967,
+  [SMALL_STATE(31)] = 986,
+  [SMALL_STATE(32)] = 1005,
+  [SMALL_STATE(33)] = 1024,
+  [SMALL_STATE(34)] = 1043,
+  [SMALL_STATE(35)] = 1062,
+  [SMALL_STATE(36)] = 1081,
+  [SMALL_STATE(37)] = 1100,
+  [SMALL_STATE(38)] = 1119,
+  [SMALL_STATE(39)] = 1138,
+  [SMALL_STATE(40)] = 1157,
+  [SMALL_STATE(41)] = 1176,
+  [SMALL_STATE(42)] = 1195,
+  [SMALL_STATE(43)] = 1214,
+  [SMALL_STATE(44)] = 1233,
+  [SMALL_STATE(45)] = 1252,
+  [SMALL_STATE(46)] = 1271,
+  [SMALL_STATE(47)] = 1290,
+  [SMALL_STATE(48)] = 1309,
+  [SMALL_STATE(49)] = 1328,
+  [SMALL_STATE(50)] = 1347,
+  [SMALL_STATE(51)] = 1366,
+  [SMALL_STATE(52)] = 1385,
+  [SMALL_STATE(53)] = 1404,
+  [SMALL_STATE(54)] = 1423,
+  [SMALL_STATE(55)] = 1442,
+  [SMALL_STATE(56)] = 1461,
+  [SMALL_STATE(57)] = 1480,
+  [SMALL_STATE(58)] = 1499,
+  [SMALL_STATE(59)] = 1518,
+  [SMALL_STATE(60)] = 1537,
+  [SMALL_STATE(61)] = 1556,
+  [SMALL_STATE(62)] = 1575,
+  [SMALL_STATE(63)] = 1594,
+  [SMALL_STATE(64)] = 1613,
+  [SMALL_STATE(65)] = 1636,
+  [SMALL_STATE(66)] = 1659,
+  [SMALL_STATE(67)] = 1684,
+  [SMALL_STATE(68)] = 1707,
+  [SMALL_STATE(69)] = 1732,
+  [SMALL_STATE(70)] = 1755,
+  [SMALL_STATE(71)] = 1780,
+  [SMALL_STATE(72)] = 1803,
+  [SMALL_STATE(73)] = 1828,
+  [SMALL_STATE(74)] = 1850,
+  [SMALL_STATE(75)] = 1872,
+  [SMALL_STATE(76)] = 1894,
+  [SMALL_STATE(77)] = 1916,
+  [SMALL_STATE(78)] = 1938,
+  [SMALL_STATE(79)] = 1960,
+  [SMALL_STATE(80)] = 1982,
+  [SMALL_STATE(81)] = 2004,
+  [SMALL_STATE(82)] = 2024,
+  [SMALL_STATE(83)] = 2038,
+  [SMALL_STATE(84)] = 2049,
+  [SMALL_STATE(85)] = 2060,
+  [SMALL_STATE(86)] = 2071,
+  [SMALL_STATE(87)] = 2082,
+  [SMALL_STATE(88)] = 2093,
+  [SMALL_STATE(89)] = 2104,
+  [SMALL_STATE(90)] = 2115,
+  [SMALL_STATE(91)] = 2131,
+  [SMALL_STATE(92)] = 2147,
+  [SMALL_STATE(93)] = 2163,
+  [SMALL_STATE(94)] = 2179,
+  [SMALL_STATE(95)] = 2195,
+  [SMALL_STATE(96)] = 2211,
+  [SMALL_STATE(97)] = 2227,
+  [SMALL_STATE(98)] = 2243,
+  [SMALL_STATE(99)] = 2259,
+  [SMALL_STATE(100)] = 2275,
+  [SMALL_STATE(101)] = 2291,
+  [SMALL_STATE(102)] = 2307,
+  [SMALL_STATE(103)] = 2323,
+  [SMALL_STATE(104)] = 2339,
+  [SMALL_STATE(105)] = 2355,
+  [SMALL_STATE(106)] = 2371,
+  [SMALL_STATE(107)] = 2387,
+  [SMALL_STATE(108)] = 2403,
+  [SMALL_STATE(109)] = 2419,
+  [SMALL_STATE(110)] = 2435,
+  [SMALL_STATE(111)] = 2451,
+  [SMALL_STATE(112)] = 2467,
+  [SMALL_STATE(113)] = 2483,
+  [SMALL_STATE(114)] = 2499,
+  [SMALL_STATE(115)] = 2515,
+  [SMALL_STATE(116)] = 2531,
+  [SMALL_STATE(117)] = 2547,
+  [SMALL_STATE(118)] = 2563,
+  [SMALL_STATE(119)] = 2579,
+  [SMALL_STATE(120)] = 2588,
+  [SMALL_STATE(121)] = 2601,
+  [SMALL_STATE(122)] = 2612,
+  [SMALL_STATE(123)] = 2625,
+  [SMALL_STATE(124)] = 2636,
+  [SMALL_STATE(125)] = 2649,
+  [SMALL_STATE(126)] = 2658,
+  [SMALL_STATE(127)] = 2667,
+  [SMALL_STATE(128)] = 2676,
+  [SMALL_STATE(129)] = 2689,
+  [SMALL_STATE(130)] = 2699,
+  [SMALL_STATE(131)] = 2709,
+  [SMALL_STATE(132)] = 2716,
+  [SMALL_STATE(133)] = 2723,
+  [SMALL_STATE(134)] = 2730,
+  [SMALL_STATE(135)] = 2737,
+  [SMALL_STATE(136)] = 2744,
+  [SMALL_STATE(137)] = 2751,
+  [SMALL_STATE(138)] = 2758,
+  [SMALL_STATE(139)] = 2765,
+  [SMALL_STATE(140)] = 2772,
+  [SMALL_STATE(141)] = 2779,
+  [SMALL_STATE(142)] = 2786,
+  [SMALL_STATE(143)] = 2793,
+  [SMALL_STATE(144)] = 2800,
+  [SMALL_STATE(145)] = 2807,
+  [SMALL_STATE(146)] = 2814,
+  [SMALL_STATE(147)] = 2821,
+  [SMALL_STATE(148)] = 2828,
+  [SMALL_STATE(149)] = 2835,
+  [SMALL_STATE(150)] = 2842,
+  [SMALL_STATE(151)] = 2849,
+  [SMALL_STATE(152)] = 2856,
+  [SMALL_STATE(153)] = 2863,
+  [SMALL_STATE(154)] = 2870,
+  [SMALL_STATE(155)] = 2877,
+  [SMALL_STATE(156)] = 2884,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {

--- a/packages/tree-sitter-pywire/test/corpus/render_regions.txt
+++ b/packages/tree-sitter-pywire/test/corpus/render_regions.txt
@@ -77,3 +77,82 @@ Head teleport
       close_name: (tag_name))
     (end_brace_block
       name: (block_keyword))))
+
+==============================
+Dynamic block (memoization escape)
+==============================
+
+{$dynamic}
+  <p>{datetime.now()}</p>
+{/dynamic}
+
+---
+
+(source_file
+  (template_section
+    (brace_block
+      keyword: (block_keyword))
+    (tag
+      name: (tag_name)
+      (interpolation
+        expr: (python_code))
+      close_name: (tag_name))
+    (end_brace_block
+      name: (block_keyword))))
+
+==============================
+Dynamic wrapping render invocation
+==============================
+
+{$dynamic}
+  {$render row(item)}
+{/dynamic}
+
+---
+
+(source_file
+  (template_section
+    (brace_block
+      keyword: (block_keyword))
+    (brace_block
+      keyword: (block_keyword)
+      expression: (python_code))
+    (end_brace_block
+      name: (block_keyword))))
+
+==============================
+Oneliner if block
+==============================
+
+{$if cond}A{/if}
+
+---
+
+(source_file
+  (template_section
+    (brace_block
+      keyword: (block_keyword)
+      expression: (python_code))
+    (text)
+    (end_brace_block
+      name: (block_keyword))))
+
+==============================
+Oneliner if/else block
+==============================
+
+{$if cond}A{$else}B{/if}
+
+---
+
+(source_file
+  (template_section
+    (brace_block
+      keyword: (block_keyword)
+      expression: (python_code))
+    (text)
+    (brace_block
+      keyword: (block_keyword))
+    (text)
+    (end_brace_block
+      name: (block_keyword))))

--- a/uv.lock
+++ b/uv.lock
@@ -2020,7 +2020,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "pywire-language-server"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "packages/pywire-language-server" }
 dependencies = [
     { name = "pygls" },


### PR DESCRIPTION
## Summary

Bundle PR addressing five open issues + a new component-memoization feature. All changes touch the `.wire` template surface — directive parsing, block syntax, attribute compilation, and snippet/component memoization.

### Closes

- Closes #155 — Oneliner `{$if}` / `{$for}` / `{$with}` blocks
- Closes #152 — `class` / `style` dict & list binding
- Closes #153 — Docs attribute interpolation cleanup
- Closes #128 — `!no_interactive` per-page directive
- Closes #126 — Memoization escape hatch

### What's in the bundle

| Issue | Approach |
|---|---|
| #155 | Grammar + codegen for paired `{$kw …}body{/kw}` on a single line. |
| #152 | Runtime normalizer (`pywire.runtime.attrs.normalize_attr`) on the `ReactiveAttribute` codegen path; `class` accepts list/tuple/dict, `style` accepts dict. |
| #153 | Docs sweep: prefer `attr={x}` over `attr="{x}"` for single-expression values. |
| #128 | New directive parser + `__no_interactive__` class flag. WebSocket **stays connected**; only event/ref handler dispatch is gated per-page. |
| #126 | New `{$dynamic}…{/dynamic}` wrapper block. Bypasses memoization for snippets, regions, components, and slot content in its subtree. |
| _new_ | Component memoization: `RenderUnit`-style cache keyed on resolved props (captured at `_resolve_component` time) + captured wire deps. `{$dynamic}` opts out. |

### Notable design notes

- `{$dynamic}` is a **wrapper block**, not a directive (`!nomemo`) or a definition modifier (`{$snippet.dynamic}`). It targets the four memoization sites uniformly: snippet defs, explicit `{$render}`, component children, and implicit `_render_region_rN` regions. Naming chosen to allow reuse for future "subtree is intentionally non-pure" optimizations (morphdom skip-equal opt-out, profiler tagging).
- `!no_interactive` keeps the WS open across SPA navigation to avoid Cloudflare connection churn. Server emits `meta.page_interactive` on every `render_update` response **and** the WS relocate payload. Client `handler.ts` runtime-checks `pageInteractive` per dispatch (handlers always wired, gating is dynamic).
- Component memoization key uses **resolved props** (captured in `_resolve_component`), not `comp.attrs` — real props (e.g. `initial=a.value`) get `setattr`'d onto the instance, so `attrs` only holds HTML pass-through and would never invalidate.

### Client fixes uncovered while verifying #128

- `dom-updater.ts:extractScripts` was stripping `<script id="_pywire_spa_meta">` from new HTML, leaving the morphed DOM with the **previous** page's meta. Now skipped during extraction so morphdom updates the script's text content in place.
- `app.ts:init` always calls `eventHandler.init()` + `refManager.init()` regardless of initial `pageInteractive`. Previously, hard-loading a `!no_interactive` page left handlers unbound for the rest of the SPA session.
- `websocket.py:relocate` attaches `meta.page_interactive` to the response payload (internal dispatch renders with `init=False`, body-only — no meta script in the fragment).

### Tests

- `test_dynamic_memoization.py` — 20 cases covering snippet bypass, sibling isolation, nested blocks, force-dirty regions, component prop / wire memo, isolation per-wire, dynamic block compile sanity, SPA-nav meta payload.
- `test_no_interactive_directive.py`
- `test_attr_normalize.py`
- `test_oneliner_blocks.py`

All 998 Python tests + 58 client vitest tests green. Tree-sitter corpus + cargo tests passing.

### Browser-verified (interactive demo at `~/projects/pywire-feature-demo`)

- `/snippet-memo` — plain snippet stays cached on unrelated bumps; `{$dynamic}` advances every bump.
- `/components` — bumping wire `a` invalidates only `card-A`; `card-B` cache hit. `always-fresh` (under `{$dynamic}`) re-runs every render.
- `/static` (`!no_interactive`) — hard-load; SPA-nav to interactive page → `pageInteractive` flips true → click events fire. Reverse direction → flag flips false → no handler firing on server.
- `/oneliner`, `/attrs` — render correctly.

## Test plan

- [x] `cd packages/pywire && uv run --extra dev pytest -q --no-cov` — 998 passed
- [x] `cd packages/pywire/src/pywire/client && pnpm test` — 58 passed
- [x] `cd packages/tree-sitter-pywire && tree-sitter test && cargo test`
- [x] Manual: snippet-memo, components, no_interactive, attrs, oneliner pages in interactive demo
- [x] CI green