### PR TITLE
feat: cross-package version floors with runtime checks

### DIFF
--- a/.agent/skills/workspace-guide/SKILL.md
+++ b/.agent/skills/workspace-guide/SKILL.md
@@ -39,6 +39,7 @@ Each package is versioned independently (`separate-pull-requests: true`).
 
 - **Don't import across package boundaries** unless it's a published package dependency (e.g., LSP depends on the `pywire` package, not the folder path).
 - **Root `scripts/`** delegate to per-package `scripts/` — actual build/test logic lives in each package's scripts.
+- **Bump version floors in lockstep** when an upstream PyWire package ships a feature a downstream package starts using. Edit BOTH `pyproject.toml` (resolver-level) AND `src/<package>/_compat.py` (runtime check). See CLAUDE.md "Version Floors" for the chain and rationale.
 
 ## Running Demos
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,33 @@ Multi-version Python testing uses **nox** in the core and language server packag
 
 GitHub Actions workflows use `dorny/paths-filter` to run checks only for packages that have changed. Release management uses `release-please` with per-package versioning.
 
+### Version Floors (cross-package compatibility)
+
+PyWire packages depend on each other in a chain: `tree-sitter-pywire` → `pywire-parser` → `pywire` / `pywire-language-server`. When an upstream package ships a feature (new grammar node, new AST class, new directive) that a downstream package starts using, the downstream package's minimum-version floor for that upstream **must be bumped in lockstep** — otherwise users with stale envs hit cryptic crashes at runtime (parser missing a directive, etc.).
+
+Two enforcement layers, both must move together:
+
+1. **`pyproject.toml` floor** — caught by pip's resolver at install time.
+2. **`_compat.py` constant** — runtime check at import; catches stale venvs that bypass the resolver (cached envs, `--no-deps`, broken lockfiles, monorepo editable drift).
+
+When you ship an upstream feature that a downstream package starts depending on:
+
+1. Release the upstream package with a new version (e.g. `pywire-parser` 0.5.0 → 0.6.0).
+2. In each downstream consumer, bump BOTH:
+   - The dep line in `pyproject.toml` (e.g. `pywire-parser>=0.6.0`)
+   - The floor in `src/<package>/_compat.py` (`_FLOORS = {"pywire-parser": "0.6.0", ...}`)
+3. Commit both edits together so release-please picks up the consumer release.
+
+Dependency chains to keep in sync:
+
+- `pywire` (`[build]` extra) → `pywire-parser` → `tree-sitter-pywire`
+- `pywire-language-server` → `pywire-parser` → `tree-sitter-pywire`
+- `pywire-cli` → `pywire[build]`, `pywire-templates`
+- `pywire-auth` → `pywire`
+- `create-pywire-app` → `pywire-templates`
+
+The JS-side packages (`vscode-pywire`, `prettier-plugin-pywire`) do **not** depend on `tree-sitter-pywire` as an npm package — they don't need floor enforcement.
+
 ### Commit Conventions (release-please)
 
 release-please uses **file paths only** to attribute commits to packages. The conventional commit scope (e.g., `fix(pywire):`) does NOT control which package gets a release PR — it only affects changelog formatting.

--- a/docs/src/content/docs/concepts/components.md
+++ b/docs/src/content/docs/concepts/components.md
@@ -239,7 +239,7 @@ To opt a single call site out of memoization — for example to force a fresh re
 {/dynamic}
 ```
 
-Memoization safety is a property of how a component is *used*, not how it's defined — wrap at the call site, not the definition.
+Memoization safety is a property of how a component is _used_, not how it's defined — wrap at the call site, not the definition.
 
 ## Component Refs
 

--- a/packages/create-pywire-app/pyproject.toml
+++ b/packages/create-pywire-app/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     "rich>=13.0.0",
     "questionary>=2.0.0",
     "jinja2>=3.1.0",
-    "pywire-templates",
+    "pywire-templates>=0.2.0",
 ]
 
 [project.scripts]

--- a/packages/create-pywire-app/src/create_pywire_app/__init__.py
+++ b/packages/create-pywire-app/src/create_pywire_app/__init__.py
@@ -1,5 +1,7 @@
 from importlib.metadata import version, PackageNotFoundError
 
+from create_pywire_app import _compat as _compat  # noqa: F401  (runs version floor checks)
+
 try:
     __version__ = version("create-pywire-app")
 except PackageNotFoundError:

--- a/packages/create-pywire-app/src/create_pywire_app/_compat.py
+++ b/packages/create-pywire-app/src/create_pywire_app/_compat.py
@@ -1,0 +1,35 @@
+"""Runtime version-floor checks for upstream packages.
+
+See packages/pywire/src/pywire/_compat.py for the rationale and
+CLAUDE.md "Version Floors" for the bump protocol.
+"""
+
+from importlib.metadata import PackageNotFoundError, version
+
+_FLOORS = {
+    "pywire-templates": "0.2.0",
+}
+
+
+def _parse(v: str) -> tuple[int, ...]:
+    out: list[int] = []
+    for chunk in v.split("."):
+        digits = ""
+        for ch in chunk:
+            if not ch.isdigit():
+                break
+            digits += ch
+        out.append(int(digits) if digits else 0)
+    return tuple(out)
+
+
+for _pkg, _min in _FLOORS.items():
+    try:
+        _installed = version(_pkg)
+    except PackageNotFoundError:
+        continue
+    if _parse(_installed) < _parse(_min):
+        raise ImportError(
+            f"create-pywire-app requires {_pkg}>={_min} but found {_installed}. "
+            f"Run: pip install -U '{_pkg}>={_min}'"
+        )

--- a/packages/pywire-auth/pyproject.toml
+++ b/packages/pywire-auth/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 requires-python = ">=3.11"
 license = "MIT"
 dependencies = [
-    "pywire",
+    "pywire>=0.13.0",
     "starlette>=0.31",
     "authlib>=1.3",
     "httpx>=0.25",

--- a/packages/pywire-auth/src/pywire_auth/__init__.py
+++ b/packages/pywire-auth/src/pywire_auth/__init__.py
@@ -15,6 +15,7 @@ Public API:
   :class:`BaseOAuth2Provider`, :class:`BaseOIDCProvider`
 """
 
+from pywire_auth import _compat as _compat  # noqa: F401  (runs version floor checks)
 from pywire_auth._protocols import AuthStore, OIDCProvider
 from pywire_auth.actions import AuthActions
 from pywire_auth.integration import connect_auth

--- a/packages/pywire-auth/src/pywire_auth/_compat.py
+++ b/packages/pywire-auth/src/pywire_auth/_compat.py
@@ -1,0 +1,35 @@
+"""Runtime version-floor checks for upstream packages.
+
+See packages/pywire/src/pywire/_compat.py for the rationale and
+CLAUDE.md "Version Floors" for the bump protocol.
+"""
+
+from importlib.metadata import PackageNotFoundError, version
+
+_FLOORS = {
+    "pywire": "0.13.0",
+}
+
+
+def _parse(v: str) -> tuple[int, ...]:
+    out: list[int] = []
+    for chunk in v.split("."):
+        digits = ""
+        for ch in chunk:
+            if not ch.isdigit():
+                break
+            digits += ch
+        out.append(int(digits) if digits else 0)
+    return tuple(out)
+
+
+for _pkg, _min in _FLOORS.items():
+    try:
+        _installed = version(_pkg)
+    except PackageNotFoundError:
+        continue
+    if _parse(_installed) < _parse(_min):
+        raise ImportError(
+            f"pywire-auth requires {_pkg}>={_min} but found {_installed}. "
+            f"Run: pip install -U '{_pkg}>={_min}'"
+        )

--- a/packages/pywire-cli/pyproject.toml
+++ b/packages/pywire-cli/pyproject.toml
@@ -23,8 +23,8 @@ classifiers = [
     "Topic :: Software Development :: Build Tools",
 ]
 dependencies = [
-    "pywire[build]",
-    "pywire-templates",
+    "pywire[build]>=0.13.0",
+    "pywire-templates>=0.2.0",
     "jinja2>=3.1.0",
     "uvicorn[standard]>=0.27.0",
     "watchfiles>=0.21.0",

--- a/packages/pywire-cli/src/pywire_cli/__init__.py
+++ b/packages/pywire-cli/src/pywire_cli/__init__.py
@@ -1,3 +1,5 @@
 """PyWire CLI — dev, build, deploy, and check tools for PyWire projects."""
 
+from pywire_cli import _compat as _compat  # noqa: F401  (runs version floor checks)
+
 __version__ = "0.2.0"

--- a/packages/pywire-cli/src/pywire_cli/_compat.py
+++ b/packages/pywire-cli/src/pywire_cli/_compat.py
@@ -1,0 +1,36 @@
+"""Runtime version-floor checks for upstream packages.
+
+See packages/pywire/src/pywire/_compat.py for the rationale and
+CLAUDE.md "Version Floors" for the bump protocol.
+"""
+
+from importlib.metadata import PackageNotFoundError, version
+
+_FLOORS = {
+    "pywire": "0.13.0",
+    "pywire-templates": "0.2.0",
+}
+
+
+def _parse(v: str) -> tuple[int, ...]:
+    out: list[int] = []
+    for chunk in v.split("."):
+        digits = ""
+        for ch in chunk:
+            if not ch.isdigit():
+                break
+            digits += ch
+        out.append(int(digits) if digits else 0)
+    return tuple(out)
+
+
+for _pkg, _min in _FLOORS.items():
+    try:
+        _installed = version(_pkg)
+    except PackageNotFoundError:
+        continue
+    if _parse(_installed) < _parse(_min):
+        raise ImportError(
+            f"pywire-cli requires {_pkg}>={_min} but found {_installed}. "
+            f"Run: pip install -U '{_pkg}>={_min}'"
+        )

--- a/packages/pywire-language-server/pyproject.toml
+++ b/packages/pywire-language-server/pyproject.toml
@@ -13,8 +13,7 @@ requires-python = ">=3.11"
 dependencies = [
     "pygls>=1.3.0",
     "ty>=0.0.15",
-    "pywire-parser>=0.5.0",
-    "pywire",
+    "pywire-parser>=0.6.0",
 ]
 
 [project.scripts]

--- a/packages/pywire-language-server/src/pywire_language_server/__init__.py
+++ b/packages/pywire-language-server/src/pywire_language_server/__init__.py
@@ -1,5 +1,7 @@
 from importlib.metadata import version, PackageNotFoundError
 
+from pywire_language_server import _compat as _compat  # noqa: F401  (runs version floor checks)
+
 try:
     __version__ = version("pywire-language-server")
 except PackageNotFoundError:

--- a/packages/pywire-language-server/src/pywire_language_server/_compat.py
+++ b/packages/pywire-language-server/src/pywire_language_server/_compat.py
@@ -1,0 +1,35 @@
+"""Runtime version-floor checks for upstream packages.
+
+See packages/pywire/src/pywire/_compat.py for the rationale and
+CLAUDE.md "Version Floors" for the bump protocol.
+"""
+
+from importlib.metadata import PackageNotFoundError, version
+
+_FLOORS = {
+    "pywire-parser": "0.6.0",
+}
+
+
+def _parse(v: str) -> tuple[int, ...]:
+    out: list[int] = []
+    for chunk in v.split("."):
+        digits = ""
+        for ch in chunk:
+            if not ch.isdigit():
+                break
+            digits += ch
+        out.append(int(digits) if digits else 0)
+    return tuple(out)
+
+
+for _pkg, _min in _FLOORS.items():
+    try:
+        _installed = version(_pkg)
+    except PackageNotFoundError:
+        continue
+    if _parse(_installed) < _parse(_min):
+        raise ImportError(
+            f"pywire-language-server requires {_pkg}>={_min} but found {_installed}. "
+            f"Run: pip install -U '{_pkg}>={_min}'"
+        )

--- a/packages/pywire-parser/pyproject.toml
+++ b/packages/pywire-parser/pyproject.toml
@@ -13,7 +13,7 @@ requires-python = ">=3.11"
 license = "MIT"
 dependencies = [
     "tree-sitter>=0.23",
-    "tree-sitter-pywire>=0.5.0",
+    "tree-sitter-pywire>=0.6.0",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/packages/pywire-parser/src/pywire_parser/__init__.py
+++ b/packages/pywire-parser/src/pywire_parser/__init__.py
@@ -5,6 +5,7 @@ include block-directive markers such as ``AuthAttribute`` that mirror
 the tree-sitter-pywire grammar.
 """
 
+from pywire_parser import _compat as _compat  # noqa: F401  (runs version floor checks)
 from pywire_parser.parser import PyWireParser
 from pywire_parser.ts_parser import parse
 from pywire_parser.ast_nodes import (

--- a/packages/pywire-parser/src/pywire_parser/_compat.py
+++ b/packages/pywire-parser/src/pywire_parser/_compat.py
@@ -1,0 +1,38 @@
+"""Runtime version-floor checks for upstream packages.
+
+See packages/pywire/src/pywire/_compat.py for the rationale and
+CLAUDE.md "Version Floors" for the bump protocol.
+"""
+
+from importlib.metadata import PackageNotFoundError, version
+
+_FLOORS = {
+    # tree-sitter-pywire ships the compiled grammar binary. New AST
+    # node types in pywire-parser require matching grammar nodes.
+    "tree-sitter-pywire": "0.6.0",
+}
+
+
+def _parse(v: str) -> tuple[int, ...]:
+    out: list[int] = []
+    for chunk in v.split("."):
+        digits = ""
+        for ch in chunk:
+            if not ch.isdigit():
+                break
+            digits += ch
+        out.append(int(digits) if digits else 0)
+    return tuple(out)
+
+
+for _pkg, _min in _FLOORS.items():
+    try:
+        _installed = version(_pkg)
+    except PackageNotFoundError:
+        continue
+    if _parse(_installed) < _parse(_min):
+        raise ImportError(
+            f"pywire-parser requires {_pkg}>={_min} but found {_installed}. "
+            f"Run: pip install -U pywire-parser  "
+            f"(or upgrade {_pkg} directly: pip install -U '{_pkg}>={_min}')"
+        )

--- a/packages/pywire/pyproject.toml
+++ b/packages/pywire/pyproject.toml
@@ -27,15 +27,18 @@ dependencies = [
     "starlette>=0.35.0",
     "python-multipart>=0.0.6",
     "msgpack>=1.0.0",
-    "pywire-parser>=0.5.0",
 ]
 
 [project.optional-dependencies]
 forms = [
     "pydantic>=2.0.0",
 ]
+# pywire-parser is required for compiling .wire files (dev mode hot
+# reload, `pywire build`, syntax-error pages). Production deployments
+# that ship pre-compiled artifacts (e.g. Cloudflare Workers via Pyodide
+# where AOT-compiled wheels aren't available) can omit this extra.
 build = [
-    "pywire-parser>=0.5.0",
+    "pywire-parser>=0.6.0",
 ]
 cli = [
     "pywire-cli",

--- a/packages/pywire/src/pywire/__init__.py
+++ b/packages/pywire/src/pywire/__init__.py
@@ -1,6 +1,8 @@
 from importlib.metadata import version, PackageNotFoundError
 from typing import Optional, TYPE_CHECKING
 
+from pywire import _compat as _compat  # noqa: F401  (runs version floor checks)
+
 try:
     __version__ = version("pywire")
 except PackageNotFoundError:

--- a/packages/pywire/src/pywire/_compat.py
+++ b/packages/pywire/src/pywire/_compat.py
@@ -1,0 +1,46 @@
+"""Runtime version-floor checks for upstream PyWire packages.
+
+When an upstream package adds features this package depends on, bump
+the floor here AND in pyproject.toml. The pyproject floor lets pip's
+resolver block bad combos at install time; this runtime check catches
+stale envs that bypass the resolver (cached venvs, --no-deps, broken
+lockfiles, monorepo editable installs that drift from pinned versions).
+
+Floors are skipped silently when the upstream package is not installed
+(extras-only deps). Lazy import sites that genuinely need the package
+are responsible for their own missing-dep error message.
+
+See CLAUDE.md "Version Floors" for the bump protocol.
+"""
+
+from importlib.metadata import PackageNotFoundError, version
+
+_FLOORS = {
+    # pywire-parser is a [build] extra. When installed, must match the
+    # AST/directive surface this pywire release was built against.
+    "pywire-parser": "0.6.0",
+}
+
+
+def _parse(v: str) -> tuple[int, ...]:
+    out: list[int] = []
+    for chunk in v.split("."):
+        digits = ""
+        for ch in chunk:
+            if not ch.isdigit():
+                break
+            digits += ch
+        out.append(int(digits) if digits else 0)
+    return tuple(out)
+
+
+for _pkg, _min in _FLOORS.items():
+    try:
+        _installed = version(_pkg)
+    except PackageNotFoundError:
+        continue
+    if _parse(_installed) < _parse(_min):
+        raise ImportError(
+            f"pywire requires {_pkg}>={_min} but found {_installed}. "
+            f"Run: pip install -U '{_pkg}>={_min}'"
+        )

--- a/packages/pywire/src/pywire/compiler/__init__.py
+++ b/packages/pywire/src/pywire/compiler/__init__.py
@@ -1,13 +1,17 @@
 """Compiler module."""
 
-from pywire.compiler.codegen.generator import CodeGenerator
-
+# Check parser presence first — the codegen import chain pulls in
+# pywire.compiler.* re-export shims which themselves require
+# pywire_parser. Without this guard, missing pywire-parser would
+# surface as a cryptic ModuleNotFoundError deep in codegen.
 try:
     from pywire_parser import PyWireParser
 except ImportError:
     raise ImportError(
         "pywire-parser is required for compiling .wire files.\n"
-        "Install it with: uv add pywire[build]  (or: pip install pywire[build])"
+        "Install it with: uv add pywire[build]  (or: pip install 'pywire[build]')"
     ) from None
+
+from pywire.compiler.codegen.generator import CodeGenerator
 
 __all__ = ["PyWireParser", "CodeGenerator"]

--- a/uv.lock
+++ b/uv.lock
@@ -1857,12 +1857,11 @@ wheels = [
 
 [[package]]
 name = "pywire"
-version = "0.12.0"
+version = "0.13.0"
 source = { editable = "packages/pywire" }
 dependencies = [
     { name = "msgpack" },
     { name = "python-multipart" },
-    { name = "pywire-parser" },
     { name = "starlette" },
 ]
 
@@ -1924,7 +1923,6 @@ requires-dist = [
     { name = "python-multipart", specifier = ">=0.0.6" },
     { name = "pywire", extras = ["cli", "forms"], marker = "extra == 'dev'", editable = "packages/pywire" },
     { name = "pywire-cli", marker = "extra == 'cli'", editable = "packages/pywire-cli" },
-    { name = "pywire-parser", editable = "packages/pywire-parser" },
     { name = "pywire-parser", marker = "extra == 'build'", editable = "packages/pywire-parser" },
     { name = "redis", marker = "extra == 'redis'", specifier = ">=5.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
@@ -2020,11 +2018,10 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "pywire-language-server"
-version = "0.6.1"
+version = "0.6.2"
 source = { editable = "packages/pywire-language-server" }
 dependencies = [
     { name = "pygls" },
-    { name = "pywire" },
     { name = "pywire-parser" },
     { name = "ty" },
 ]
@@ -2048,7 +2045,6 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
-    { name = "pywire", editable = "packages/pywire" },
     { name = "pywire-parser", editable = "packages/pywire-parser" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
     { name = "ty", specifier = ">=0.0.15" },
@@ -2079,7 +2075,7 @@ requires-dist = [
 
 [[package]]
 name = "pywire-parser"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "packages/pywire-parser" }
 dependencies = [
     { name = "tree-sitter" },
@@ -2471,7 +2467,7 @@ wheels = [
 
 [[package]]
 name = "tree-sitter-pywire"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "packages/tree-sitter-pywire" }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Stops the "I bumped pywire but parser is stale → cryptic crash" failure mode. Each PyWire package that depends on another now enforces a minimum-version floor at **two layers**:

1. **`pyproject.toml`** — pip's resolver blocks bad combos at install time.
2. **`<pkg>/_compat.py`** — runtime check at import; catches stale envs that bypass the resolver (cached venvs, `--no-deps`, broken lockfiles, monorepo editable drift). Fails fast with an actionable `pip install -U …` hint instead of a `ModuleNotFoundError` or AST-node-not-found error deep in parsing.

Also drops the `pywire` dep from `pywire-language-server` (verified unused via grep) and moves `pywire-parser` from `pywire`'s base deps to the `[build]` extra. Production deployments shipping pre-compiled `.wire` artifacts (e.g. Cloudflare Workers via Pyodide where AOT-compiled wheels aren't available) no longer pull tree-sitter into the runtime; anything that compiles `.wire` files at runtime must add `pywire[build]`.

## Bump protocol

When an upstream package adds a feature a downstream consumer starts using, bump BOTH the pyproject floor AND the `_compat.py` constant in lockstep. Documented in `CLAUDE.md` "Version Floors" + workspace-guide skill.

## Dependency chains enforced

- `pywire[build]` → `pywire-parser` → `tree-sitter-pywire`
- `pywire-language-server` → `pywire-parser` → `tree-sitter-pywire`
- `pywire-cli` → `pywire[build]`, `pywire-templates`
- `pywire-auth` → `pywire`
- `create-pywire-app` → `pywire-templates`

JS-side packages (`vscode-pywire`, `prettier-plugin-pywire`) don't depend on `tree-sitter-pywire` as an npm package — no floor needed there.

## Commits per package (release-please paths)

- `feat(pywire)` — `_compat.py` + parser → `[build]` extra + reorder compiler import-error
- `feat(pywire-parser)` — `_compat.py` + `tree-sitter-pywire>=0.6.0`
- `feat(pywire-language-server)` — `_compat.py` + `pywire-parser>=0.6.0`; drop unused `pywire` dep
- `feat(pywire-cli)` — `_compat.py` + bumped floors for `pywire[build]` & `pywire-templates`
- `feat(pywire-auth)` — `_compat.py` + `pywire>=0.13.0`
- `feat(create-pywire-app)` — `_compat.py` + `pywire-templates>=0.2.0`
- `chore` — CLAUDE.md + workspace-guide skill + uv.lock

## Test plan

- [x] Smoke import: all six consumer packages import clean in editable monorepo
- [x] Floor-fail path: monkey-patched `tree-sitter-pywire` to `0.5.0` → ImportError fires with upgrade hint
- [x] Silent-skip path: `pywire-parser` absent → `pywire._compat` passes (extras pattern)
- [x] `ruff format --check` + `ruff check` clean across all six packages
- [x] `ty check src` clean (pre-existing diagnostics in `pywire-parser/directives/auth.py` and `pywire-auth` are unchanged from `main`)
- [x] pytest: pywire 998 ✓ · pywire-parser 13 ✓ · pywire-language-server 37 ✓ · pywire-cli 37 ✓ · pywire-auth 99 ✓ · create-pywire-app 26 ✓
- [ ] CI green
- [ ] Verify release-please opens PRs only for the six packages with `feat:` commits (not for the `chore:` commit)

## Follow-ups (out of scope)

- Stronger split between dev/build runtime and production runtime in `pywire/runtime/loader.py` so `[build]`-less envs can still serve pre-compiled artifacts cleanly. Today the lazy `from pywire.compiler.parser import …` inside `loader.py` is gated by the new `compiler/__init__.py` check, but the surrounding code still assumes parser availability for hot reload.