### PR TITLE
fix(pywire-docs): keepalive pings prevent WS heartbeat disconnect

### DIFF
--- a/docs/public/shim.py
+++ b/docs/public/shim.py
@@ -100,6 +100,11 @@ async def handle_js_message(event_data):
                 to_js(accept_payload, dict_converter=js.Object.fromEntries)
             )
 
+            # Cancel any orphaned tasks from a previous WS connection
+            for _t in list(getattr(handle_js_message, "_ws_tasks", [])):
+                _t.cancel()
+            handle_js_message._ws_tasks = []
+
             # Start forwarding outgoing WS messages to JS
             async def forward_ws_messages():
                 try:
@@ -119,7 +124,23 @@ async def handle_js_message(event_data):
                 except Exception as e:
                     print(f"WS forward error: {e}")
 
-            asyncio.create_task(forward_ws_messages())
+            # Send periodic pings so the client heartbeat (deadConnectionMs=40s)
+            # doesn't close the socket during idle periods (reading tutorial text, etc.)
+            async def send_keepalive():
+                import msgpack as _msgpack
+                _ping_bytes = list(_msgpack.packb({"type": "ping"}))
+                _ping_msg = {"type": "websocket.send", "bytes": _ping_bytes}
+                while True:
+                    await asyncio.sleep(15)
+                    try:
+                        _payload = {"type": "ws_message", "id": req_id, "message": _ping_msg}
+                        js.postMessage(to_js(_payload, dict_converter=js.Object.fromEntries))
+                    except Exception:
+                        break
+
+            fwd_task = asyncio.create_task(forward_ws_messages())
+            ka_task = asyncio.create_task(send_keepalive())
+            handle_js_message._ws_tasks = [fwd_task, ka_task]
 
         elif event_type == "ws_send":
             adp = get_adapter()
@@ -129,12 +150,15 @@ async def handle_js_message(event_data):
                 data = event_data["data"]
                 if isinstance(data, list):
                     data = bytes(data)
-                    # Rewrite tutorial paths
                     try:
                         import msgpack
                         payload = msgpack.unpackb(data)
-                        if isinstance(payload, dict) and "path" in payload:
-                            if payload["path"].startswith("/docs/"):
+                        if isinstance(payload, dict):
+                            # Silently drop pong responses to our keepalive pings
+                            if payload.get("type") == "pong":
+                                return
+                            # Rewrite tutorial paths
+                            if "path" in payload and payload["path"].startswith("/docs/"):
                                 payload["path"] = "/"
                                 data = msgpack.packb(payload)
                     except Exception:
@@ -174,6 +198,10 @@ js.reload_page = reload_page
 def restart_server(pages_dir="/app"):
     global app_instance, adapter, current_pages_dir
     print(f"restart_server called with pages_dir={pages_dir}")
+    # Cancel orphaned WS tasks from the previous session
+    for _t in list(getattr(handle_js_message, "_ws_tasks", [])):
+        _t.cancel()
+    handle_js_message._ws_tasks = []
     app_instance = None
     adapter = None
     current_pages_dir = pages_dir

--- a/docs/src/content/docs/concepts/components.md
+++ b/docs/src/content/docs/concepts/components.md
@@ -239,7 +239,7 @@ To opt a single call site out of memoization — for example to force a fresh re
 {/dynamic}
 ```
 
-Memoization safety is a property of how a component is *used*, not how it's defined — wrap at the call site, not the definition.
+Memoization safety is a property of how a component is _used_, not how it's defined — wrap at the call site, not the definition.
 
 ## Component Refs
 


### PR DESCRIPTION
## Summary

- `WebSocketTransport` closes the socket after 40 s of no server messages (`deadConnectionMs = 40000`). The Pyodide tutorial server is idle after the initial page load, so users reading tutorial text see "Reconnecting…" every ~40 s.
- Shim now sends a msgpack `{type: "ping"}` frame every 15 s; the client updates `lastMessageTime` and responds with `{type: "pong"}`; the pong is dropped in `ws_send` before reaching the PyWire app.
- Orphaned `forward_ws_messages` + keepalive tasks are cancelled on new `ws_connect` and on `restart_server` to prevent stale tasks leaking pings into the new connection.

## Changes

- `docs/public/shim.py` — add `send_keepalive` task, pong-drop in `ws_send`, task cleanup in `ws_connect` and `restart_server`

## Test plan

- [ ] Open the interactive tutorial, wait >40 s without clicking anything — confirm "Reconnecting…" overlay no longer appears
- [ ] Navigate between tutorial steps — confirm server restarts cleanly with no orphaned ping tasks in console
- [ ] Click interactive elements in the preview — confirm normal WS round-trips still work