### PR TITLE
fix: auth-demo SPA cookie + codegen scope + -in-for regressions

### DIFF
--- a/packages/pywire-parser/pyproject.toml
+++ b/packages/pywire-parser/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pywire-parser"
-version = "0.7.0"
+version = "0.8.0"
 description = "Pure-Python parser for PyWire .wire files using tree-sitter"
 authors = [
     { name = "Reece Holmdahl", email = "reece@pywire.dev" },

--- a/packages/pywire-parser/src/pywire_parser/ast_nodes.py
+++ b/packages/pywire-parser/src/pywire_parser/ast_nodes.py
@@ -281,13 +281,24 @@ class AuthAttribute(SpecialAttribute):
     Region-scoped auth gate. Parallel to the page-level ``!auth``
     directive but evaluates per-region and renders an "allowed" or
     "denied" branch rather than redirecting the whole page.
+
+    ``claims`` is set when every claim value parsed as a string
+    literal — fast path for codegen. ``claims_expr`` carries the
+    raw kwarg expression when at least one value is not a literal
+    (e.g. a loop variable like ``[("tier", tier)]``); codegen
+    evaluates it at runtime so the gate sees the current iteration's
+    value.
     """
 
     policy: Optional[str] = None
     claims: Optional[List[Tuple[str, Optional[str]]]] = None
+    claims_expr: Optional[str] = None
 
     def __str__(self) -> str:
-        return f"AuthAttribute(policy={self.policy}, claims={self.claims})"
+        return (
+            f"AuthAttribute(policy={self.policy}, claims={self.claims}, "
+            f"claims_expr={self.claims_expr})"
+        )
 
 
 @dataclass

--- a/packages/pywire-parser/src/pywire_parser/parser.py
+++ b/packages/pywire-parser/src/pywire_parser/parser.py
@@ -773,9 +773,7 @@ class PyWireParser:
 
 def _parse_auth_kwargs(
     expr: str,
-) -> Tuple[
-    Optional[str], Optional[List[Tuple[str, Optional[str]]]], Optional[str]
-]:
+) -> Tuple[Optional[str], Optional[List[Tuple[str, Optional[str]]]], Optional[str]]:
     """Parse ``{$auth policy=... claims=[...]}`` expression text.
 
     Accepts kwargs or a positional string (treated as ``policy``).

--- a/packages/pywire-parser/src/pywire_parser/parser.py
+++ b/packages/pywire-parser/src/pywire_parser/parser.py
@@ -457,13 +457,14 @@ class PyWireParser:
                 )
             )
         elif kw == "auth":
-            policy, claims = _parse_auth_kwargs(expr or "")
+            policy, claims, claims_expr = _parse_auth_kwargs(expr or "")
             node.special_attributes.append(
                 AuthAttribute(
                     name="$auth",
                     value="",
                     policy=policy,
                     claims=claims,
+                    claims_expr=claims_expr,
                     line=rn.line,
                     column=rn.column,
                 )
@@ -772,32 +773,43 @@ class PyWireParser:
 
 def _parse_auth_kwargs(
     expr: str,
-) -> Tuple[Optional[str], Optional[List[Tuple[str, Optional[str]]]]]:
+) -> Tuple[
+    Optional[str], Optional[List[Tuple[str, Optional[str]]]], Optional[str]
+]:
     """Parse ``{$auth policy=... claims=[...]}`` expression text.
 
-    Accepts kwargs or a positional string (treated as ``policy``). Returns
-    ``(policy, claims)`` — either may be ``None`` when omitted.
+    Accepts kwargs or a positional string (treated as ``policy``).
+    Returns ``(policy, claims, claims_expr)``:
 
-    Claims entries may be strings (claim type, any value) or
-    tuples/lists of ``(type, value)``. Parse failures silently degrade to
-    ``(None, None)`` — runtime evaluation fails closed.
+    - ``claims`` is populated when every claim value is a string literal
+      — fast path so the compiler can emit a constant list without a
+      runtime evaluation step.
+    - ``claims_expr`` is the raw source text of the ``claims=`` kwarg
+      when at least one claim value is a non-literal expression (e.g.
+      a loop variable in ``{$for tier in ...}{$auth claims=[("tier",
+      tier)]}...``). Codegen evaluates it at runtime so each iteration
+      sees its own value.
+
+    Parse failures silently degrade to ``(None, None, None)`` — runtime
+    evaluation fails closed.
     """
     raw = expr.strip()
     if not raw:
-        return None, None
+        return None, None, None
 
     # Wrap as call so we can read keywords uniformly.
     try:
         wrapped = ast.parse(f"_auth_call({raw})", mode="eval")
     except (SyntaxError, ValueError):
-        return None, None
+        return None, None, None
 
     call = wrapped.body
     if not isinstance(call, ast.Call):
-        return None, None
+        return None, None, None
 
     policy: Optional[str] = None
     claims: Optional[List[Tuple[str, Optional[str]]]] = None
+    claims_expr: Optional[str] = None
 
     # Positional string → policy (matches page-level !auth "Name" shorthand).
     if call.args:
@@ -813,6 +825,9 @@ def _parse_auth_kwargs(
         elif kw.arg == "claims":
             v = kw.value
             if not isinstance(v, ast.List):
+                # Non-list expressions still get the runtime path so a
+                # user can pass a variable holding a list: claims=user_claims.
+                claims_expr = ast.unparse(v)
                 continue
             parsed: List[Tuple[str, Optional[str]]] = []
             ok = True
@@ -834,5 +849,9 @@ def _parse_auth_kwargs(
                 break
             if ok:
                 claims = parsed
+            else:
+                # At least one entry is dynamic — defer the whole list to
+                # runtime so loop / wire variables resolve per render.
+                claims_expr = ast.unparse(v)
 
-    return policy, claims
+    return policy, claims, claims_expr

--- a/packages/pywire/pyproject.toml
+++ b/packages/pywire/pyproject.toml
@@ -38,7 +38,7 @@ forms = [
 # that ship pre-compiled artifacts (e.g. Cloudflare Workers via Pyodide
 # where AOT-compiled wheels aren't available) can omit this extra.
 build = [
-    "pywire-parser>=0.6.0",
+    "pywire-parser>=0.8.0",
 ]
 # jinja2 backs the dev-mode compile-error page renderer (error_renderer.py);
 # `pywire run` with debug=False never imports it. It belongs on the dev/cli

--- a/packages/pywire/src/pywire/_compat.py
+++ b/packages/pywire/src/pywire/_compat.py
@@ -18,7 +18,7 @@ from importlib.metadata import PackageNotFoundError, version
 _FLOORS = {
     # pywire-parser is a [build] extra. When installed, must match the
     # AST/directive surface this pywire release was built against.
-    "pywire-parser": "0.6.0",
+    "pywire-parser": "0.8.0",
 }
 
 

--- a/packages/pywire/src/pywire/compiler/codegen/template.py
+++ b/packages/pywire/src/pywire/compiler/codegen/template.py
@@ -35,6 +35,24 @@ from pywire.compiler.ast_nodes import (
 from pywire.compiler.interpolation.brace import BraceInterpolationParser
 
 
+def _comprehension_target_names(target: ast.expr) -> List[str]:
+    """Return the bare names bound by a comprehension target.
+
+    Handles tuple/list unpacking and starred targets (e.g.
+    ``for a, *rest in items``). Attribute or subscript targets bind
+    no new local name.
+    """
+    out: List[str] = []
+    if isinstance(target, ast.Name):
+        out.append(target.id)
+    elif isinstance(target, (ast.Tuple, ast.List)):
+        for elt in target.elts:
+            out.extend(_comprehension_target_names(elt))
+    elif isinstance(target, ast.Starred):
+        out.extend(_comprehension_target_names(target.value))
+    return out
+
+
 class TemplateCodegen:
     """Generates Python AST for rendering template."""
 
@@ -380,6 +398,61 @@ class TemplateCodegen:
 
                 node.value = self.visit(node.value)
                 node.target = self.visit(node.target)
+                return node
+
+            # Comprehensions create their own scope: targets are local to
+            # the comprehension and must not be rewritten to self.<name>.
+            # Without this, ``[(c.type, c.value) for c in user.claims]``
+            # compiles to ``[(self.c.type, ...) for self.c in ...]``,
+            # leaking ``c`` (the last loop value) onto the page instance.
+            def _visit_comprehension(self, node: Any) -> Any:
+                added: list[str] = []
+                for gen in node.generators:
+                    for name in _comprehension_target_names(gen.target):
+                        if name not in local_vars:
+                            local_vars.add(name)
+                            added.append(name)
+                try:
+                    self.generic_visit(node)
+                finally:
+                    for name in added:
+                        local_vars.discard(name)
+                return node
+
+            def visit_ListComp(self, node: ast.ListComp) -> Any:
+                return self._visit_comprehension(node)
+
+            def visit_SetComp(self, node: ast.SetComp) -> Any:
+                return self._visit_comprehension(node)
+
+            def visit_DictComp(self, node: ast.DictComp) -> Any:
+                return self._visit_comprehension(node)
+
+            def visit_GeneratorExp(self, node: ast.GeneratorExp) -> Any:
+                return self._visit_comprehension(node)
+
+            def visit_Lambda(self, node: ast.Lambda) -> Any:
+                # Lambda parameters are local to the lambda body.
+                added: list[str] = []
+                for arg in (
+                    list(node.args.args)
+                    + list(node.args.posonlyargs)
+                    + list(node.args.kwonlyargs)
+                ):
+                    if arg.arg not in local_vars:
+                        local_vars.add(arg.arg)
+                        added.append(arg.arg)
+                if node.args.vararg and node.args.vararg.arg not in local_vars:
+                    local_vars.add(node.args.vararg.arg)
+                    added.append(node.args.vararg.arg)
+                if node.args.kwarg and node.args.kwarg.arg not in local_vars:
+                    local_vars.add(node.args.kwarg.arg)
+                    added.append(node.args.kwarg.arg)
+                try:
+                    self.generic_visit(node)
+                finally:
+                    for name in added:
+                        local_vars.discard(name)
                 return node
 
         new_tree = AddSelfTransformer().visit(tree)
@@ -1001,6 +1074,10 @@ class TemplateCodegen:
         )
 
         # state = self._auth_states.get(region_id, {"status": "pending"})
+        # ``region_id`` is the function parameter — the call site computes
+        # it dynamically when claims contain runtime values (loop vars,
+        # wires, etc.) so each iteration of an enclosing $for keeps its
+        # own auth state.
         body.append(
             ast.Assign(
                 targets=[ast.Name(id="state", ctx=ast.Store())],
@@ -1015,7 +1092,7 @@ class TemplateCodegen:
                         ctx=ast.Load(),
                     ),
                     args=[
-                        ast.Constant(value=region_id),
+                        ast.Name(id="region_id", ctx=ast.Load()),
                         ast.Dict(
                             keys=[ast.Constant(value="status")],
                             values=[ast.Constant(value="pending")],
@@ -1119,7 +1196,7 @@ class TemplateCodegen:
             name=func_name,
             args=ast.arguments(
                 posonlyargs=[],
-                args=[ast.arg(arg="self")],
+                args=[ast.arg(arg="self"), ast.arg(arg="region_id")],
                 vararg=None,
                 kwonlyargs=[],
                 kw_defaults=[],
@@ -2383,15 +2460,17 @@ class TemplateCodegen:
                     else:
                         authorizing_body.append(child)
 
-            region_id = f"auth_{node.line}_{node.column}".replace("-", "_")
-            method_name = f"_render_auth_{region_id}"
-            self.region_renderers[region_id] = method_name
+            static_region_id = (
+                f"auth_{node.line}_{node.column}".replace("-", "_")
+            )
+            method_name = f"_render_auth_{static_region_id}"
+            self.region_renderers[static_region_id] = method_name
             if self._dynamic_codegen_depth > 0:
-                self.dynamic_regions.add(region_id)
+                self.dynamic_regions.add(static_region_id)
 
             aux_func = self._generate_auth_renderer(
                 method_name,
-                region_id,
+                static_region_id,
                 authorizing_body,
                 allowed_body,
                 denied_body,
@@ -2407,9 +2486,33 @@ class TemplateCodegen:
             )
             self.auxiliary_functions.append(aux_func)
 
-            # Build _resolve_auth(region_id, policy=..., claims=...) call.
-            claims_expr: ast.expr = ast.Constant(value=None)
-            if auth_attr.claims:
+            # Unique local var names per source position so nested $auth
+            # blocks don't collide. The variables hold the per-iteration
+            # region_id and claims tuple; both feed the cache key + the
+            # background resolver call.
+            slug = f"{node.line}_{node.column}".replace("-", "_")
+            claims_var = f"_pw_auth_claims_{slug}"
+            region_var = f"_pw_auth_region_{slug}"
+
+            # Build claims expression. Static literals stay as a literal
+            # AST list; non-constants (loop vars / wires) come through
+            # the runtime path so each iteration sees its own value.
+            claims_value_ast: ast.expr
+            if auth_attr.claims_expr is not None:
+                claims_value_ast = cast(
+                    ast.expr,
+                    self._transform_expr(
+                        auth_attr.claims_expr,
+                        local_vars,
+                        known_globals,
+                        known_imports,
+                        line_offset=node.line,
+                        col_offset=node.column,
+                        cached=False,
+                        wire_vars=wire_vars,
+                    ),
+                )
+            elif auth_attr.claims:
                 tuple_elts: List[ast.expr] = []
                 for ctype, cvalue in auth_attr.claims:
                     tuple_elts.append(
@@ -2421,7 +2524,35 @@ class TemplateCodegen:
                             ctx=ast.Load(),
                         )
                     )
-                claims_expr = ast.List(elts=tuple_elts, ctx=ast.Load())
+                claims_value_ast = ast.List(elts=tuple_elts, ctx=ast.Load())
+            else:
+                claims_value_ast = ast.Constant(value=None)
+
+            # claims_var = <evaluated claims>
+            body.append(
+                ast.Assign(
+                    targets=[ast.Name(id=claims_var, ctx=ast.Store())],
+                    value=claims_value_ast,
+                )
+            )
+            # region_var = self._auth_region_id(static_id, claims_var)
+            body.append(
+                ast.Assign(
+                    targets=[ast.Name(id=region_var, ctx=ast.Store())],
+                    value=ast.Call(
+                        func=ast.Attribute(
+                            value=ast.Name(id="self", ctx=ast.Load()),
+                            attr="_auth_region_id",
+                            ctx=ast.Load(),
+                        ),
+                        args=[
+                            ast.Constant(value=static_region_id),
+                            ast.Name(id=claims_var, ctx=ast.Load()),
+                        ],
+                        keywords=[],
+                    ),
+                )
+            )
 
             resolve_kwargs: List[ast.keyword] = []
             if auth_attr.policy is not None:
@@ -2430,12 +2561,20 @@ class TemplateCodegen:
                         arg="policy", value=ast.Constant(value=auth_attr.policy)
                     )
                 )
-            if auth_attr.claims:
-                resolve_kwargs.append(ast.keyword(arg="claims", value=claims_expr))
+            if (
+                auth_attr.claims is not None
+                or auth_attr.claims_expr is not None
+            ):
+                resolve_kwargs.append(
+                    ast.keyword(
+                        arg="claims",
+                        value=ast.Name(id=claims_var, ctx=ast.Load()),
+                    )
+                )
 
             start_task_stmt = ast.If(
                 test=ast.Compare(
-                    left=ast.Constant(value=region_id),
+                    left=ast.Name(id=region_var, ctx=ast.Load()),
                     ops=[ast.NotIn()],
                     comparators=[
                         ast.Attribute(
@@ -2461,7 +2600,7 @@ class TemplateCodegen:
                                         attr="_resolve_auth",
                                         ctx=ast.Load(),
                                     ),
-                                    args=[ast.Constant(value=region_id)],
+                                    args=[ast.Name(id=region_var, ctx=ast.Load())],
                                     keywords=resolve_kwargs,
                                 )
                             ],
@@ -2509,6 +2648,7 @@ class TemplateCodegen:
             )
             body.append(start_task_stmt)
 
+            # parts.append(f'<div data-pw-region="{region_var}" style="...">')
             body.append(
                 ast.Expr(
                     value=ast.Call(
@@ -2518,8 +2658,19 @@ class TemplateCodegen:
                             ctx=ast.Load(),
                         ),
                         args=[
-                            ast.Constant(
-                                value=f'<div data-pw-region="{region_id}" style="display: contents;">'
+                            ast.JoinedStr(
+                                values=[
+                                    ast.Constant(value='<div data-pw-region="'),
+                                    ast.FormattedValue(
+                                        value=ast.Name(
+                                            id=region_var, ctx=ast.Load()
+                                        ),
+                                        conversion=-1,
+                                    ),
+                                    ast.Constant(
+                                        value='" style="display: contents;">'
+                                    ),
+                                ]
                             )
                         ],
                         keywords=[],
@@ -2542,7 +2693,9 @@ class TemplateCodegen:
                                         attr=method_name,
                                         ctx=ast.Load(),
                                     ),
-                                    args=[],
+                                    args=[
+                                        ast.Name(id=region_var, ctx=ast.Load())
+                                    ],
                                     keywords=[],
                                 )
                             )

--- a/packages/pywire/src/pywire/compiler/codegen/template.py
+++ b/packages/pywire/src/pywire/compiler/codegen/template.py
@@ -2460,9 +2460,7 @@ class TemplateCodegen:
                     else:
                         authorizing_body.append(child)
 
-            static_region_id = (
-                f"auth_{node.line}_{node.column}".replace("-", "_")
-            )
+            static_region_id = f"auth_{node.line}_{node.column}".replace("-", "_")
             method_name = f"_render_auth_{static_region_id}"
             self.region_renderers[static_region_id] = method_name
             if self._dynamic_codegen_depth > 0:
@@ -2561,10 +2559,7 @@ class TemplateCodegen:
                         arg="policy", value=ast.Constant(value=auth_attr.policy)
                     )
                 )
-            if (
-                auth_attr.claims is not None
-                or auth_attr.claims_expr is not None
-            ):
+            if auth_attr.claims is not None or auth_attr.claims_expr is not None:
                 resolve_kwargs.append(
                     ast.keyword(
                         arg="claims",
@@ -2662,14 +2657,10 @@ class TemplateCodegen:
                                 values=[
                                     ast.Constant(value='<div data-pw-region="'),
                                     ast.FormattedValue(
-                                        value=ast.Name(
-                                            id=region_var, ctx=ast.Load()
-                                        ),
+                                        value=ast.Name(id=region_var, ctx=ast.Load()),
                                         conversion=-1,
                                     ),
-                                    ast.Constant(
-                                        value='" style="display: contents;">'
-                                    ),
+                                    ast.Constant(value='" style="display: contents;">'),
                                 ]
                             )
                         ],
@@ -2693,9 +2684,7 @@ class TemplateCodegen:
                                         attr=method_name,
                                         ctx=ast.Load(),
                                     ),
-                                    args=[
-                                        ast.Name(id=region_var, ctx=ast.Load())
-                                    ],
+                                    args=[ast.Name(id=region_var, ctx=ast.Load())],
                                     keywords=[],
                                 )
                             )

--- a/packages/pywire/src/pywire/runtime/page.py
+++ b/packages/pywire/src/pywire/runtime/page.py
@@ -1,5 +1,6 @@
 """Base page class with lifecycle system."""
 
+import hashlib
 import inspect
 import re
 import asyncio
@@ -12,6 +13,7 @@ from typing import (
     Callable,
     ClassVar,
     Dict,
+    Iterable,
     List,
     Optional,
     Set,
@@ -1330,6 +1332,18 @@ class BasePage:
         # template that may have been invalidated).
         self._region_output_cache.clear()
         self._snippet_invocations.clear()
+        # Layouts and child components hold their own snippet/output
+        # caches keyed against state on this (parent) page — auth states,
+        # regions, etc. A full re-render here is usually triggered by a
+        # state change the children's caches don't know about, so clear
+        # them too. Without this, the layout component would serve a
+        # stale cached children body and overwrite the fresh output.
+        for comp in list(getattr(self, "_components", {}).values()):
+            try:
+                comp._snippet_invocations.clear()
+                comp._region_output_cache.clear()
+            except AttributeError:
+                pass
 
     def _begin_region_render(self, region_id: str) -> None:
         deps = self._region_dependencies.get(region_id)
@@ -1424,6 +1438,20 @@ class BasePage:
         if regions:
             self._dirty_regions.update(regions)
 
+        # Bubble up to the parent page so its ``render_update`` sees the
+        # invalidation. Layouts and child components register wire reads on
+        # themselves (their ``_render_template`` runs under their own
+        # render-context), so without this propagation the page that the
+        # WS handler calls ``render_update`` on would never see the wires
+        # written by the user's handler — UI freezes despite the wire
+        # change. Marking the parent's root (None) dirty triggers a full
+        # re-render, which is the safe outcome since the parent has no
+        # finer-grained subscription for this wire.
+        parent = getattr(self, "_parent_page", None)
+        if parent is not None:
+            parent._dirty_regions.add(None)
+            parent._wire_write_seq += 1
+
     async def handle_event(
         self, event_name: str, event_data: dict[str, Any]
     ) -> Dict[str, Any]:
@@ -1515,7 +1543,14 @@ class BasePage:
                 for region_id in sorted(self._dirty_regions):
                     method_name = region_map.get(region_id)
                     if not method_name:
-                        continue
+                        # Dynamic regions (e.g. ``{$auth claims=[("tier",
+                        # tier)]}`` inside ``{$for}``) carry an iteration
+                        # suffix, so they don't appear in the static
+                        # ``__region_renderers__`` map. Silently skipping
+                        # would leave the UI stuck on the previous state
+                        # — fall back to a full re-render instead.
+                        has_root_dirty = True
+                        break
                     renderer = getattr(self, method_name, None)
                     if not renderer:
                         continue
@@ -1687,7 +1722,7 @@ class BasePage:
         region_id: str,
         *,
         policy: Optional[str] = None,
-        claims: Optional[List[Tuple[str, Optional[str]]]] = None,
+        claims: Optional[Iterable[Tuple[str, Optional[str]]]] = None,
     ) -> None:
         """Background task backing the ``{$auth}`` directive.
 
@@ -1725,6 +1760,30 @@ class BasePage:
             await self.push_state()
         except Exception:
             pass
+
+    @staticmethod
+    def _auth_region_id(static_id: str, claims: Any) -> str:
+        """Build a per-iteration region id for ``{$auth}``.
+
+        The static id encodes the source position. When ``claims`` is
+        ``None`` or empty (no per-iteration variation) the static id is
+        returned unchanged so the existing partial-render path still
+        targets a stable element. When claims are present — including
+        loop-variable values from ``{$for}`` — they're folded into the
+        id so each iteration maintains its own auth state and its own
+        ``data-pw-region`` attribute, avoiding collisions where one
+        morphdom patch would otherwise overwrite a sibling's content.
+        """
+        if not claims:
+            return static_id
+        try:
+            normalized = tuple(
+                (str(t), None if v is None else str(v)) for t, v in claims
+            )
+        except Exception:
+            return static_id
+        suffix = hashlib.md5(repr(normalized).encode("utf-8")).hexdigest()[:8]
+        return f"{static_id}_{suffix}"
 
     async def _render_template(self) -> str:
         """Render template - implemented by codegen."""

--- a/packages/pywire/src/pywire/runtime/session_serializer.py
+++ b/packages/pywire/src/pywire/runtime/session_serializer.py
@@ -145,7 +145,13 @@ def snapshot_page_state(page: Any, *, warn_size: int = 0) -> Dict[str, Any]:
         if _is_serializable(value):
             attrs[name] = value
         else:
-            logger.warning(
+            # Frontmatter often holds non-picklable handles (e.g. an
+            # ``idp = app.state.local_idp`` reference, an open DB engine,
+            # or a third-party SDK client). These are reconstructed by
+            # ``__top_level_init__`` on every page instantiation, so
+            # losing them from the snapshot is harmless. Log at debug
+            # rather than warning so this isn't noise on every persist.
+            logger.debug(
                 "Skipping non-serializable attr '%s' (%s) on %s",
                 name,
                 type(value).__name__,

--- a/packages/pywire/src/pywire/runtime/websocket.py
+++ b/packages/pywire/src/pywire/runtime/websocket.py
@@ -908,20 +908,20 @@ class WebSocketHandler:
         baseline = self._get_handshake_cookies(websocket)
 
         # 0. Infer HttpOnly for any baseline cookie the client can't see,
-        #    but ONLY on the first reconcile for this connection AND when
-        #    the client reports at least one cookie. Rationale:
+        #    but ONLY on the first reconcile for this connection. Rationale:
         #      - document.cookie omits HttpOnly by definition; first-time
-        #        absence from a non-empty client payload implies HttpOnly.
+        #        absence from the client payload implies HttpOnly.
         #      - On subsequent reconciles we trust the client: the user
         #        may have legitimately cleared a non-HttpOnly cookie via
         #        devtools or JS.
-        #      - If the first reconcile's client payload is empty we
-        #        can't distinguish HttpOnly from "no cookies at all";
-        #        be conservative and skip the inference — later tombstone
-        #        logic correctly drops baseline cookies the client no
-        #        longer reports.
+        #      - When the first reconcile's client payload is empty we
+        #        can't distinguish HttpOnly from "user cleared all cookies".
+        #        Default to HttpOnly: losing an auth session on the first
+        #        SPA-nav after login is a much worse failure mode than
+        #        carrying a deleted-via-JS non-HttpOnly cookie until the
+        #        next hard reload (which clears the WS jar entirely).
         first_reconcile = websocket not in self._connection_reconciled
-        if cookie_header is not None and first_reconcile and client_cookies:
+        if cookie_header is not None and first_reconcile:
             for key in baseline:
                 if key not in client_cookies:
                     httponly_set.add(key)

--- a/packages/pywire/tests/test_auth_block.py
+++ b/packages/pywire/tests/test_auth_block.py
@@ -276,3 +276,127 @@ async def test_nested_inside_for_loop():
         assert resolved.count("[admin]") == 2
     finally:
         reset_auth_context(tok)
+
+
+# ---------------------------------------------------------------------------
+# Per-iteration claim values (loop variable in claims=[...]) — regression
+# coverage for the bug where every iteration shared one ``region_id`` and
+# the parser silently dropped non-constant claim values.
+# ---------------------------------------------------------------------------
+
+
+def test_parser_captures_dynamic_claims_expression():
+    """A non-constant claim value (loop var, wire, etc.) is preserved as
+    raw expression text so codegen can evaluate it at runtime."""
+    from pywire_parser import PyWireParser
+    from pywire_parser.ast_nodes import AuthAttribute
+
+    result = PyWireParser().parse(
+        "---\n---\n"
+        '{$for tier in ["free", "beta"]}'
+        '{$auth claims=[("tier", tier)]}<p>x</p>{/auth}'
+        "{/for}\n"
+    )
+    auth_attrs = [
+        a
+        for n in result.template
+        for a in n.special_attributes
+        if isinstance(a, AuthAttribute)
+    ] + [
+        a
+        for top in result.template
+        for n in top.children
+        for a in n.special_attributes
+        if isinstance(a, AuthAttribute)
+    ]
+    assert len(auth_attrs) == 1
+    assert auth_attrs[0].claims is None
+    assert auth_attrs[0].claims_expr is not None
+    assert "tier" in auth_attrs[0].claims_expr
+
+
+@pytest.mark.asyncio
+async def test_per_iteration_claims_evaluate_independently():
+    """``{$auth claims=[("tier", tier)]}`` inside a $for must check each
+    iteration's claim value, not collapse to one shared region.
+
+    Regression: pre-fix the parser dropped the dynamic value (``tier``)
+    silently and every iteration fell back to "is_authenticated", so a
+    user without ``tier=free`` still rendered the allowed branch on the
+    free row. After the fix the iterations split into separate region
+    ids each carrying their own claim tuple.
+    """
+    cls = _compile(
+        "<ul>"
+        '{$for tier in ["free", "beta"]}'
+        '<li>{tier}: {$auth claims=[("tier", tier)]}[on]{$else}[off]{/auth}</li>'
+        "{/for}"
+        "</ul>"
+    )
+    user = ClaimsPrincipal(
+        is_authenticated=True,
+        name="test",
+        user_id="x:1",
+        claims=[Claim(type="tier", value="beta")],
+    )
+    ctx = AuthContext(
+        principal=user, engine=PolicyEngine(), channel=MemoryAuthChannel()
+    )
+    tok = set_auth_context(ctx)
+    try:
+        page = cls(request=None, params={}, query={}, path={}, url=None)
+        page.user = user
+        await page._render_template()
+        for _ in range(10):
+            await asyncio.sleep(0)
+        # Caches on the page reflect prior renders; force-clear so the
+        # next render reads the now-resolved auth states (mirrors the
+        # production full-rerender fallback in render_update).
+        page._snippet_invocations.clear()
+        page._region_output_cache.clear()
+        resolved = await page._render_template()
+
+        free_li = resolved[
+            resolved.index("<li>free:") : resolved.index("</li>", resolved.index("<li>free:"))
+        ]
+        beta_li = resolved[
+            resolved.index("<li>beta:") : resolved.index("</li>", resolved.index("<li>beta:"))
+        ]
+        assert "[off]" in free_li, (
+            f"free iteration should be denied (user lacks tier=free); got: {free_li}"
+        )
+        assert "[on]" in beta_li, (
+            f"beta iteration should be allowed (user has tier=beta); got: {beta_li}"
+        )
+
+        # Each iteration must emit its own ``data-pw-region`` so morphdom
+        # patches don't overwrite a sibling's content.
+        import re as _re
+
+        ids = _re.findall(r'data-pw-region="(auth_[^"]+)"', resolved)
+        assert len(ids) == 2 and ids[0] != ids[1], (
+            f"expected two distinct auth region ids per iteration, got {ids}"
+        )
+    finally:
+        reset_auth_context(tok)
+
+
+def test_codegen_emits_dynamic_region_id_for_loop_var_claim():
+    """Sanity check: compiled output uses ``self._auth_region_id(...)``
+    with the per-iteration claims tuple so the region id varies."""
+    import ast as _ast
+    from pywire.compiler.parser import PyWireParser
+    from pywire.compiler.codegen.generator import CodeGenerator
+
+    src = (
+        "---\n---\n"
+        '{$for tier in ["free", "beta"]}'
+        '<li>{$auth claims=[("tier", tier)]}[on]{$else}[off]{/auth}</li>'
+        "{/for}\n"
+    )
+    parsed = PyWireParser().parse(src)
+    out = _ast.unparse(CodeGenerator().generate(parsed))
+    assert "_auth_region_id" in out
+    # The runtime claims list must reference the loop var ``tier`` (not
+    # be flattened to a static literal).
+    assert "[('tier', tier)]" in out

--- a/packages/pywire/tests/test_codegen_template.py
+++ b/packages/pywire/tests/test_codegen_template.py
@@ -62,6 +62,49 @@ class TestCodegenTemplate(unittest.TestCase):
         transformed = self.codegen._transform_expr(expr, local_vars={"item"})
         self.assert_ast_equal(transformed, "item.name == 'Test'")
 
+    def test_transform_expr_list_comp_target_not_promoted(self) -> None:
+        # Regression: comprehension target was being rewritten to ``self.c``,
+        # leaking the last loop value onto the page instance and triggering
+        # session-serializer warnings ("Skipping non-serializable attr 'c'").
+        expr = "[(c.type, c.value) for c in items]"
+        transformed = self.codegen._transform_expr(expr, local_vars=set())
+        self.assert_ast_equal(
+            transformed,
+            "[(c.type, c.value) for c in self.items]",
+        )
+
+    def test_transform_expr_dict_comp_target_not_promoted(self) -> None:
+        expr = "{c.type: c.value for c in items if c.type != 'sub'}"
+        transformed = self.codegen._transform_expr(expr, local_vars=set())
+        self.assert_ast_equal(
+            transformed,
+            "{c.type: c.value for c in self.items if c.type != 'sub'}",
+        )
+
+    def test_transform_expr_nested_comp_target_not_promoted(self) -> None:
+        expr = "[(a, b) for a in xs for b in ys]"
+        transformed = self.codegen._transform_expr(expr, local_vars=set())
+        self.assert_ast_equal(
+            transformed,
+            "[(a, b) for a in self.xs for b in self.ys]",
+        )
+
+    def test_transform_expr_comp_tuple_unpack_not_promoted(self) -> None:
+        expr = "[k for (k, v) in items]"
+        transformed = self.codegen._transform_expr(expr, local_vars=set())
+        self.assert_ast_equal(
+            transformed,
+            "[k for k, v in self.items]",
+        )
+
+    def test_transform_expr_lambda_arg_not_promoted(self) -> None:
+        expr = "(lambda x: x + 1)(value)"
+        transformed = self.codegen._transform_expr(expr, local_vars=set())
+        self.assert_ast_equal(
+            transformed,
+            "(lambda x: x + 1)(self.value)",
+        )
+
     def test_transform_reactive_expr_auto_call(self) -> None:
         # Parameterless method should be auto-called
         expr = "my_method"

--- a/packages/pywire/tests/test_e2e_middleware_replay.py
+++ b/packages/pywire/tests/test_e2e_middleware_replay.py
@@ -551,3 +551,29 @@ class TestHttpOnlyCookieStaysAuthoritative:
             msg = _ws_relocate(ws, "/dashboard", cookies="")
             assert msg["type"] == "update"
             assert "Dashboard" in msg.get("html", "")
+
+    def test_handshake_httponly_survives_first_relocate_with_empty_cookies(self):
+        """Regression: HttpOnly cookie set BEFORE the WS handshake (via a prior
+        HTTP login → full reload) is in the handshake headers but not in
+        ``document.cookie``. The first relocate's empty client payload must
+        not tombstone it.
+        """
+        # Simulate: user logged in over HTTP earlier, browser stored the
+        # HttpOnly session cookie, page reloaded → new WS connection whose
+        # handshake carries the cookie in the request headers.
+        headers = {"cookie": "secret=ok"}
+        with self.client.websocket_connect(
+            "/_pywire/ws", headers=headers
+        ) as ws:
+            _ws_init(ws, "/")
+
+            # First relocate after login. document.cookie is empty because
+            # ``secret`` is HttpOnly. Server must infer HttpOnly for any
+            # baseline cookie missing from the empty client payload — not
+            # tombstone them.
+            msg = _ws_relocate(ws, "/dashboard", cookies="")
+            assert msg["type"] == "update", (
+                f"Expected logged-in render; got {msg.get('type')} "
+                f"(path={msg.get('path')}). The session cookie was tombstoned."
+            )
+            assert "Dashboard" in msg.get("html", "")

--- a/packages/pywire/tests/test_hot_reload_wire_tracking.py
+++ b/packages/pywire/tests/test_hot_reload_wire_tracking.py
@@ -217,3 +217,73 @@ class TestWireTrackingWithLayout:
             assert len(update["regions"]) > 0, (
                 "render_update returned empty regions — wire tracking broken"
             )
+
+
+# ---------------------------------------------------------------------------
+# Wire reads outside any region (at the layout-body root) must still
+# trigger updates on the parent page when written.
+# ---------------------------------------------------------------------------
+
+
+# A page with a layout where a wire is read at the BODY ROOT — outside any
+# inner region. The `$if` gate means ``token_state`` is read by the body
+# closure under the layout component's render context, not by an inner
+# region renderer. Without the parent-bubble in ``_invalidate_wire``, the
+# wire write only dirties the layout component — the page that the WS
+# handler calls ``render_update`` on stays clean and the UI freezes.
+ROOT_READ_LAYOUT = """\
+<!DOCTYPE html>
+<html><body><main>{$render children}</main></body></html>
+"""
+
+ROOT_READ_PAGE = """\
+!layout "__layout__.wire"
+
+---
+token = wire("")
+
+def issue():
+    token.value = "ok"
+---
+<button @click={issue}>Issue</button>
+<article $if={token}>
+    <pre>{token}</pre>
+</article>
+"""
+
+
+class TestParentInvalidatesOnChildWireWrite:
+    """Wire writes inside a layout-component-rendered body must propagate
+    to the parent page so its ``render_update`` re-renders the UI."""
+
+    @pytest.mark.asyncio
+    async def test_handler_wire_write_under_layout_dirties_parent(
+        self, tmp_path: Path
+    ) -> None:
+        (tmp_path / "__layout__.wire").write_text(ROOT_READ_LAYOUT)
+        (tmp_path / "page.wire").write_text(ROOT_READ_PAGE)
+        loader = PageLoader()
+        PageClass = loader.load(
+            tmp_path / "page.wire",
+            implicit_layout=str((tmp_path / "__layout__.wire").resolve()),
+        )
+
+        page = _create_page(PageClass)
+        await page.render(init=True)
+
+        # Click the button: handler writes to the wire. The wire was read
+        # at the body root (under the layout component's context), so
+        # without the bubble fix only the layout component sees the
+        # invalidation and the page returns no regions / empty html.
+        update = await page.handle_event("issue", {})
+        assert isinstance(update, dict)
+        if update.get("type") == "regions":
+            assert update.get("regions"), (
+                "wire write under layout body root did not dirty the parent "
+                "page — UI would not update"
+            )
+        elif update.get("type") == "full":
+            assert update.get("html"), (
+                "full re-render returned empty html after wire write under "
+                "layout body root"
+            )

--- a/uv.lock
+++ b/uv.lock
@@ -547,7 +547,7 @@ toml = [
 
 [[package]]
 name = "create-pywire-app"
-version = "0.11.0"
+version = "0.12.0"
 source = { editable = "packages/create-pywire-app" }
 dependencies = [
     { name = "jinja2" },

--- a/uv.lock
+++ b/uv.lock
@@ -2078,7 +2078,7 @@ requires-dist = [
 
 [[package]]
 name = "pywire-parser"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "packages/pywire-parser" }
 dependencies = [
     { name = "tree-sitter" },


### PR DESCRIPTION
## Summary

Five regressions surfaced by the `pywire-auth-demo` after PR #181 / pywire 0.14.0 made the auth flow visible end-to-end. Each fix is independent and lands with a regression test that fails pre-fix.

### 1. WS cookie reconcile silently dropped HttpOnly session
First SPA-nav after login → server saw no session cookie → `AuthMiddleware` returned `ANONYMOUS` → next page rendered as logged-out.

`_reconcile_from_client_cookies` only inferred HttpOnly for baseline cookies missing from the client payload **when the payload was non-empty**. With only the HttpOnly `pywire_session` in the browser, `document.cookie === ""`, the inference was skipped, and the tombstone pass at the end nuked the session.

Drop the `and client_cookies` guard. Trade-off: a JS-deleted non-HttpOnly cookie may persist in the WS jar until the next hard reload — losing an auth session is the worse failure.

### 2. List/dict/set/generator comprehension targets leaked to `self.<name>`
Codegen rewrote every bare `Name` to `self.Name`. `[(c.type, c.value) for c in user.claims]` compiled to `[(self.c.type, …) for self.c in self.user.claims]`, leaving the last loop value on the page instance — trigger for session-serializer warnings ("Skipping non-serializable attr 'c' (Claim) on LiveViewPage") and a bug magnet. `AddSelfTransformer` now overrides comprehension/lambda visitors to scope target names locally.

### 3. Wire writes inside layout-rendered bodies didn't dirty the parent
With a layout, the page body runs under the layout component's render context; wire reads at the body root register on the **layout**, not the page that the WS handler calls `render_update` on. UI froze even though the handler ran. `_invalidate_wire` now bubbles to `_parent_page` (mark root dirty).

### 4. `{$auth}` in `{$for}` collapsed to a single shared region + lost dynamic claims
- The parser's `_parse_auth_kwargs` only accepted string literals and silently dropped the whole `claims=` kwarg when any value was a name; `claims=[("tier", tier)]` parsed to `claims=None`, falling back to a bare `is_authenticated` check.
- `region_id = f"auth_{line}_{column}"` was static per source position, so two iterations of `$for` shared one `data-pw-region` and one auth state.

Now the parser preserves the raw kwarg as `AuthAttribute.claims_expr`, codegen evaluates it at runtime via `_transform_expr` (with `self.` rewriting), and a per-iteration id `_auth_region_id(static_id, claims)` (md5 of the claim tuple) goes into both the `<div data-pw-region>` and the `_resolve_auth` background-task call. The aux renderer takes `region_id` as a parameter so one method serves every iteration.

### 5. Supporting fixes
- `render_update` now falls back to a full re-render when a dirty region isn't in the static `__region_renderers__` map (covers dynamic `{$auth}` ids that resolve after the first render).
- `_clear_wire_tracking` also clears child-component snippet/output caches; without this, the layout component would serve a stale cached body after the page falls back to a full re-render.
- Session serializer demotes the "Skipping non-serializable attr" log from WARNING to DEBUG. Frontmatter handles like `idp = app.state.local_idp` are recreated by `__top_level_init__` on every page instantiation.

### Auth demo behavior

```
Before:                       After:
free: [enabled]               free: [locked]    (user lacks tier=free)
beta:                         beta: [enabled]   (user has tier=beta)
```

### Version-floor bump

Bumps pywire's `pywire-parser` floor to `>=0.8.0` (pyproject + `_compat.py`) for the new `AuthAttribute.claims_expr` field. Once release-please releases `pywire-parser` 0.8.0, the next `pywire` release picks up the new floor.

## Test plan

- [x] `cd packages/pywire && uv run --extra dev pytest tests/ -q` — 1008 passed
- [x] `cd packages/pywire-parser && uv run pytest -q` — 13 passed
- [x] `cd packages/pywire-auth && uv run --extra sqlalchemy --extra dev pytest -q` — 99 passed
- [x] Each new regression test verified failing on `origin/main` (file checkout + rerun) before the fix is applied
- [x] End-to-end: login + SPA-nav across `/auth_block`, `/token`, `/live_view` against the local pywire-auth-demo — auth state holds across navs, token button updates the UI, beta-tier `$auth` shows `[enabled]` while free shows `[locked]`
- [ ] CI green