### PR TITLE
fix(pywire-docs): revert pong-drop; add PyPI version-check cache

### DIFF
--- a/docs/public/shim.py
+++ b/docs/public/shim.py
@@ -124,23 +124,8 @@ async def handle_js_message(event_data):
                 except Exception as e:
                     print(f"WS forward error: {e}")
 
-            # Send periodic pings so the client heartbeat (deadConnectionMs=40s)
-            # doesn't close the socket during idle periods (reading tutorial text, etc.)
-            async def send_keepalive():
-                import msgpack as _msgpack
-                _ping_bytes = list(_msgpack.packb({"type": "ping"}))
-                _ping_msg = {"type": "websocket.send", "bytes": _ping_bytes}
-                while True:
-                    await asyncio.sleep(15)
-                    try:
-                        _payload = {"type": "ws_message", "id": req_id, "message": _ping_msg}
-                        js.postMessage(to_js(_payload, dict_converter=js.Object.fromEntries))
-                    except Exception:
-                        break
-
             fwd_task = asyncio.create_task(forward_ws_messages())
-            ka_task = asyncio.create_task(send_keepalive())
-            handle_js_message._ws_tasks = [fwd_task, ka_task]
+            handle_js_message._ws_tasks = [fwd_task]
 
         elif event_type == "ws_send":
             adp = get_adapter()
@@ -150,15 +135,12 @@ async def handle_js_message(event_data):
                 data = event_data["data"]
                 if isinstance(data, list):
                     data = bytes(data)
+                    # Rewrite tutorial paths
                     try:
                         import msgpack
                         payload = msgpack.unpackb(data)
-                        if isinstance(payload, dict):
-                            # Silently drop pong responses to our keepalive pings
-                            if payload.get("type") == "pong":
-                                return
-                            # Rewrite tutorial paths
-                            if "path" in payload and payload["path"].startswith("/docs/"):
+                        if isinstance(payload, dict) and "path" in payload:
+                            if payload["path"].startswith("/docs/"):
                                 payload["path"] = "/"
                                 data = msgpack.packb(payload)
                     except Exception:

--- a/docs/src/pywire-worker.ts
+++ b/docs/src/pywire-worker.ts
@@ -91,15 +91,33 @@ importlib.invalidate_caches()
       cacheKey = ''
     }
 
+    // For PyPI mode, query PyPI for the latest pywire version so we can detect
+    // when the cache is stale and a newer release is available.
+    let latestPywireVersion = ''
+    if (__PYWIRE_INSTALL_SOURCE__ === 'pypi') {
+      try {
+        const resp = await fetch('https://pypi.org/pypi/pywire/json')
+        if (resp.ok) {
+          const data = await resp.json()
+          latestPywireVersion = (data as any).info?.version ?? ''
+          console.log('[Worker] Latest pywire on PyPI:', latestPywireVersion)
+        }
+      } catch (e) {
+        console.warn('[Worker] PyPI version check failed (will use cache if available):', e)
+      }
+    }
+
     // Escape for safe interpolation into Python string literals
     const safeCacheKey = cacheKey.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
     const safeMarkerFile = markerFile.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+    const safeLatestPywire = latestPywireVersion.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
 
     const checkResult = await pyodide.runPythonAsync(`
 import os, sys, importlib
 cache_valid = False
 marker_path = "${safeMarkerFile}"
 expected_key = "${safeCacheKey}"
+latest_pywire = "${safeLatestPywire}"
 if expected_key and os.path.exists(marker_path):
     stored_key = open(marker_path).read().strip()
     if stored_key == expected_key:
@@ -112,8 +130,27 @@ if expected_key and os.path.exists(marker_path):
             print(f"[Python] Cache invalid, import failed: {e}")
     else:
         print(f"[Python] Cache key mismatch, will reinstall")
+elif os.path.exists(marker_path):
+    stored_key = open(marker_path).read().strip()
+    if stored_key.startswith("pypi|"):
+        installed_pywire = next(
+            (p.split("==")[1] for p in stored_key.split("|") if p.startswith("pywire==")),
+            "",
+        )
+        if installed_pywire and (not latest_pywire or installed_pywire == latest_pywire):
+            try:
+                import pywire
+                from pywire_parser.ts_parser import PYWIRE_LANGUAGE
+                cache_valid = True
+                print(f"[Python] PyPI cache valid: pywire=={installed_pywire}")
+            except Exception as e:
+                print(f"[Python] PyPI cache import failed: {e}")
+        else:
+            print(f"[Python] pywire update: {installed_pywire} → {latest_pywire or 'latest'}")
+    else:
+        print("[Python] Unknown cache format, will reinstall")
 else:
-    print("[Python] No cache marker found or PyPI mode (will check versions)")
+    print("[Python] No cache marker found (first install)")
 cache_valid
 `)
 


### PR DESCRIPTION
## Summary

Follow-up to #190 which introduced a regression.

### Bug introduced in #190

`send_keepalive` sent `{type:"ping"}` frames directly to the client. The client responded with `{type:"pong"}` via `ws_send`. The pong-drop in `ws_send` discarded ALL pongs — including responses to PyWire's own built-in server-side pings. PyWire's ping timeout fired and closed the socket immediately after connect.

**Fix:** Remove `send_keepalive` (redundant — PyWire's server pings already keep `lastMessageTime` fresh on the client) and remove the pong-drop. Keep orphaned-task cleanup on new `ws_connect` and `restart_server`.

### PyPI version-check cache (bonus)

In `pywire-worker.ts` PyPI mode, the IDBFS cache marker was written with installed versions but the check guard (`if expected_key`) was always false (empty string), so packages reinstalled on every page load.

**Fix:** Fetch `https://pypi.org/pypi/pywire/json` before the cache check. Compare installed version to latest. If they match → use IDBFS cache (fast repeat loads). If PyPI has a newer release → reinstall. If version fetch fails (offline) → use cache conservatively.

## Test plan

- [ ] Open tutorial, immediately interact — confirm no `WebSocket ping timeout` in console
- [ ] Leave tutorial idle for >40 s — confirm no "Reconnecting…" overlay
- [ ] Reload tutorial with warm cache — confirm `[Python] PyPI cache valid` log (fast load)
- [ ] (Simulate update) Clear marker, reload — confirm fresh install runs