### PR TITLE
fix(pywire): bind props namespace + seat snippet kwargs on first paint

### DIFF
--- a/packages/pywire/src/pywire/compiler/codegen/generator.py
+++ b/packages/pywire/src/pywire/compiler/codegen/generator.py
@@ -192,7 +192,10 @@ class CodeGenerator:
             ),
             ast.ImportFrom(
                 module="pywire.core.props",
-                names=[ast.alias(name="props", asname=None)],
+                names=[
+                    ast.alias(name="props", asname=None),
+                    ast.alias(name="PropsNamespace", asname="_PywirePropsNamespace"),
+                ],
                 level=0,
             ),
             ast.ImportFrom(
@@ -1415,6 +1418,24 @@ class CodeGenerator:
 
         return transformed
 
+    def _build_props_namespace_assign(self, prop_names: Set[str]) -> ast.Assign:
+        """Emit ``props = _PywirePropsNamespace(name=name, ...)``.
+
+        Tutorial and docs teach ``{props.x}``; bare-name unpacking exists
+        for ``{x}`` ergonomics. Bind both forms so either works.
+        """
+        return ast.Assign(
+            targets=[ast.Name(id="props", ctx=ast.Store())],
+            value=ast.Call(
+                func=ast.Name(id="_PywirePropsNamespace", ctx=ast.Load()),
+                args=[],
+                keywords=[
+                    ast.keyword(arg=name, value=ast.Name(id=name, ctx=ast.Load()))
+                    for name in sorted(prop_names)
+                ],
+            ),
+        )
+
     def _extract_props_from_class(self, node: ast.ClassDef) -> PropsDirective:
         """Extract props from a @props decorated class."""
         args: List[Tuple[str, str, Optional[str]]] = []
@@ -1656,6 +1677,10 @@ class CodeGenerator:
                             ),
                         )
                     )
+                props_unpack_stmts.append(
+                    self._build_props_namespace_assign(prop_names)
+                )
+                prop_names.add("props")
 
             body_func, aux_funcs = self.template_codegen.generate_render_method(
                 parsed.template,
@@ -1857,6 +1882,10 @@ class CodeGenerator:
                             ),
                         )
                     )
+                props_unpack_stmts.append(
+                    self._build_props_namespace_assign(prop_names)
+                )
+                prop_names.add("props")
 
             render_func, aux_funcs = self.template_codegen.generate_render_method(
                 parsed.template,

--- a/packages/pywire/src/pywire/core/props.py
+++ b/packages/pywire/src/pywire/core/props.py
@@ -1,4 +1,4 @@
-from typing import Type, TypeVar
+from typing import Any, Type, TypeVar
 
 T = TypeVar("T", bound=Type)
 
@@ -14,3 +14,29 @@ def props(cls: T) -> T:
     """
     setattr(cls, "_pywire_props", True)
     return cls
+
+
+class PropsNamespace:
+    """Read-only namespace exposing declared props inside a template.
+
+    Codegen unpacks props as bare locals (so ``{name}`` works) and also
+    binds ``props`` to one of these so ``{props.name}`` works too. The
+    docs and tutorials teach the ``props.x`` form; the bare form is an
+    implementation detail of the unpacking.
+    """
+
+    __slots__ = ("_values",)
+
+    def __init__(self, **values: Any) -> None:
+        object.__setattr__(self, "_values", values)
+
+    def __getattr__(self, name: str) -> Any:
+        values = object.__getattribute__(self, "_values")
+        if name in values:
+            return values[name]
+        raise AttributeError(name)
+
+    def __repr__(self) -> str:  # pragma: no cover - debug only
+        values = object.__getattribute__(self, "_values")
+        body = ", ".join(f"{k}={v!r}" for k, v in values.items())
+        return f"PropsNamespace({body})"

--- a/packages/pywire/src/pywire/runtime/page.py
+++ b/packages/pywire/src/pywire/runtime/page.py
@@ -236,6 +236,17 @@ class BasePage:
         # through into ``self.attrs`` where it would leak into HTML rendering.
         children_arg = kwargs.pop("children", None)
 
+        # Named snippet props (e.g. ``header={...}``) must land on ``self``
+        # so ``{$render header}`` can resolve them via attribute lookup on
+        # first render. Without this, only re-renders (which go through
+        # ``_update_props``) would see the snippet — first paint always
+        # falls back to the placeholder body.
+        snippet_kwargs: Dict[str, Snippet] = {}
+        for key in [k for k, v in kwargs.items() if isinstance(v, Snippet)]:
+            snippet_kwargs[key] = kwargs.pop(key)
+        for key, value in snippet_kwargs.items():
+            setattr(self, key, value)
+
         # Store remaining kwargs as fallthrough attributes
         self.attrs = dict(kwargs)
 

--- a/packages/pywire/tests/test_codegen_generator.py
+++ b/packages/pywire/tests/test_codegen_generator.py
@@ -156,6 +156,29 @@ class TestCodeGenerator(unittest.TestCase):
         assert "self.count = count" in code
         assert "self.variant = variant" in code
 
+    def test_props_namespace_binding(self) -> None:
+        """``props.x`` form should resolve to a namespace, not the decorator."""
+        source = dedent("""
+            ---
+            from pywire import props
+
+            @props
+            class Props:
+                text: str
+                color: str = "gray"
+            ---
+            <span>{props.text} {props.color}</span>
+        """)
+        parser = PyWireParser()
+        parsed = parser.parse(source, "test.wire")
+        module_ast = self.generator.generate(parsed)
+        code = ast.unparse(module_ast)
+        assert "_PywirePropsNamespace" in code
+        # Both bare-name and namespace bindings emitted
+        assert "text = self.text" in code
+        assert "color = self.color" in code
+        assert "props = _PywirePropsNamespace(" in code
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/packages/pywire/tests/test_snippet_codegen.py
+++ b/packages/pywire/tests/test_snippet_codegen.py
@@ -233,6 +233,65 @@ from pkg.list_comp import List
 
 
 @pytest.mark.asyncio
+async def test_named_snippet_without_props_declaration(tmp_path, monkeypatch):
+    """Child component without ``@props`` still receives named snippets.
+
+    Repro for tutorial step 33 bug: ``{$snippet header}`` in the parent
+    must populate ``self.header`` on the child on first render so the
+    paired ``{$render header}fallback{/render}`` form picks the override
+    instead of the fallback. Previously only ``_update_props`` (called on
+    re-render) bound snippets to ``self``; first paint always fell back.
+    """
+    import sys
+    import types as _types
+
+    card_src = """<div class="card">
+<header>
+{$render header}Untitled{/render}
+</header>
+<section>{$render children}</section>
+</div>
+"""
+    page_src = """---
+from pkg.card_comp import Card
+---
+<div>
+<Card>
+{$snippet header}Product Details{/snippet}
+<p>body</p>
+</Card>
+</div>
+"""
+
+    parsed_card = PyWireParser().parse(card_src, "/virtual/pkg/card.wire")
+    card_mod_ast = CodeGenerator().generate(parsed_card)
+    py_ast.fix_missing_locations(card_mod_ast)
+    card_code = compile(card_mod_ast, filename="<card>", mode="exec")
+    card_ns: dict[str, Any] = {"__name__": "pkg.card_comp"}
+    exec(card_code, card_ns)
+    card_ns["Card"] = card_ns["CardPage"]
+
+    card_module = _types.ModuleType("pkg.card_comp")
+    card_module.__dict__.update(card_ns)
+    monkeypatch.setitem(sys.modules, "pkg.card_comp", card_module)
+    pkg_mod = _types.ModuleType("pkg")
+    monkeypatch.setitem(sys.modules, "pkg", pkg_mod)
+
+    parsed_page = PyWireParser().parse(page_src, "/virtual/page.wire")
+    page_mod_ast = CodeGenerator().generate(parsed_page)
+    py_ast.fix_missing_locations(page_mod_ast)
+    page_code = compile(page_mod_ast, filename="<page>", mode="exec")
+    page_ns: dict[str, Any] = {"__name__": "page"}
+    exec(page_code, page_ns)
+    PageCls = page_ns["PagePage"]
+
+    page = PageCls(_make_request(), {}, {})
+    html = await page._render_template()
+    assert "Product Details" in html
+    assert "Untitled" not in html
+
+
+@pytest.mark.asyncio
 async def test_optional_snippet_none_raises_without_fallback():
     """Unpaired ``{$render name(args)}`` on a None snippet raises,
     signaling that a fallback should have been provided."""


### PR DESCRIPTION
## Summary

- Codegen now binds ``props = PropsNamespace(...)`` after unpacking declared prop names as bare locals, so both ``{x}`` and ``{props.x}`` resolve correctly. Previously ``{props.x}`` resolved to the imported ``@props`` decorator (a function) and raised ``AttributeError``.
- ``BasePage.__init__`` mirrors ``_update_props``: ``Snippet``-typed kwargs are seated as instance attributes before the rest become ``attrs``. First-paint components now see passed-in named snippets; previously only re-renders picked them up, so paired ``{$render name}fallback{/render}`` always showed the fallback on initial render.

Both fixes have regression tests; full pywire suite (999 tests) green.

Tutorial changes that depend on this release land in a follow-up PR.

## Test plan
- [x] ``uv run --extra dev pytest`` (999 pass)
- [ ] Manual verification of tutorial steps 22, 23, 33, 34 once docs PR lands