### PR TITLE
fix(pywire-docs): disconnect prior PyWireApp before doc.write

### DIFF
--- a/docs/public/shim.py
+++ b/docs/public/shim.py
@@ -209,6 +209,98 @@ def reload_page(path_str):
 js.reload_page = reload_page
 
 
+def delete_file(path_str):
+    """Delete a file from the virtual FS and drop it from the loader cache.
+
+    Mirrors reload_page's lazy semantics: if the adapter doesn't exist yet,
+    we still remove the file from disk but skip the loader call.
+    """
+    import os
+    import pathlib
+
+    try:
+        if os.path.exists(path_str):
+            os.remove(path_str)
+        if adapter is not None:
+            try:
+                adapter.app.reload_page(pathlib.Path(path_str))
+            except Exception:
+                # File no longer exists — loader will drop it on next access
+                pass
+        return True
+    except Exception as e:
+        print(f"delete_file failed for {path_str}: {e}")
+        traceback.print_exc()
+        return False
+
+
+js.delete_file = delete_file
+
+
+def sync_pages(pages_dir, files):
+    """Atomic file-set sync: write `files`, delete anything else under pages_dir.
+
+    `files` is a JS object {relpath: content}. Paths are written under /app/.
+    Files under pages_dir but not in `files` are deleted. After all FS edits,
+    we invalidate the loader cache for each touched path so next request
+    sees fresh source.
+    """
+    global current_pages_dir
+    import os
+    import pathlib
+
+    try:
+        # Convert JS object → dict if needed
+        if hasattr(files, "to_py"):
+            files_dict = files.to_py()
+        else:
+            files_dict = dict(files)
+
+        # Resolve pages_dir to absolute /app/...
+        if pages_dir and not pages_dir.startswith("/"):
+            abs_pages_dir = f"/app/{pages_dir}"
+        else:
+            abs_pages_dir = pages_dir or "/app"
+        current_pages_dir = abs_pages_dir
+
+        # Compute target absolute paths for all incoming files
+        target_paths = set()
+        for rel, content in files_dict.items():
+            abs_path = f"/app/{rel}"
+            target_paths.add(os.path.normpath(abs_path))
+            os.makedirs(os.path.dirname(abs_path), exist_ok=True)
+            with open(abs_path, "w") as f:
+                f.write(content)
+
+        # Delete anything under pages_dir not in target_paths
+        if os.path.exists(abs_pages_dir):
+            for root, _dirs, fnames in os.walk(abs_pages_dir):
+                for fname in fnames:
+                    full = os.path.normpath(os.path.join(root, fname))
+                    if full not in target_paths:
+                        try:
+                            os.remove(full)
+                        except Exception:
+                            pass
+
+        # Invalidate loader cache for each touched file (and anything we deleted).
+        # If adapter not built yet, skip — next request builds fresh.
+        if adapter is not None:
+            for p in target_paths:
+                try:
+                    adapter.app.reload_page(pathlib.Path(p))
+                except Exception:
+                    pass
+        return True
+    except Exception as e:
+        print(f"sync_pages failed: {e}")
+        traceback.print_exc()
+        return False
+
+
+js.sync_pages = sync_pages
+
+
 def restart_server(pages_dir="/app"):
     global app_instance, adapter, current_pages_dir
     print(f"restart_server called with pages_dir={pages_dir}")

--- a/docs/src/components/tutorial/BrowserPreview.tsx
+++ b/docs/src/components/tutorial/BrowserPreview.tsx
@@ -25,6 +25,12 @@ export const BrowserPreview: React.FC<BrowserPreviewProps> = ({
 }) => {
   const [inputValue, setInputValue] = React.useState(url)
   const [isRefreshing, setIsRefreshing] = React.useState(false)
+  // Refresh rebuilds the iframe doc (full doc.write), which kills the
+  // MockWebSocket and forces a reconnect. Spam-clicking would race
+  // multiple reconnects, occasionally tripping the heartbeat timeout
+  // path inside the iframe and the "session expired" toast. Rate-limit
+  // the button so each click rebuilds at most once per cooldown.
+  const lastReloadAt = React.useRef(0)
 
   // Sync input value with external url prop changes
   React.useEffect(() => {
@@ -41,6 +47,10 @@ export const BrowserPreview: React.FC<BrowserPreviewProps> = ({
     e.preventDefault()
     e.stopPropagation()
     e.nativeEvent.stopImmediatePropagation()
+
+    const now = performance.now()
+    if (now - lastReloadAt.current < 500) return
+    lastReloadAt.current = now
 
     setIsRefreshing(true)
     ;(window as any).__PYWIRE_PREVIEW_RELOAD__?.()

--- a/docs/src/components/tutorial/BrowserPreview.tsx
+++ b/docs/src/components/tutorial/BrowserPreview.tsx
@@ -6,6 +6,10 @@ interface BrowserPreviewProps {
   url: string
   onMessage: (msg: any) => void
   onNavigate?: (path: string) => void
+  onBack?: () => void
+  onForward?: () => void
+  canBack?: boolean
+  canForward?: boolean
   theme?: 'light' | 'dark'
 }
 
@@ -13,6 +17,10 @@ export const BrowserPreview: React.FC<BrowserPreviewProps> = ({
   url,
   onMessage,
   onNavigate,
+  onBack,
+  onForward,
+  canBack = false,
+  canForward = false,
   theme = 'dark',
 }) => {
   const [inputValue, setInputValue] = React.useState(url)
@@ -67,10 +75,12 @@ export const BrowserPreview: React.FC<BrowserPreviewProps> = ({
               e.preventDefault()
               e.stopPropagation()
               e.nativeEvent.stopImmediatePropagation()
-              ;(window as any).__PYWIRE_PREVIEW_BACK__?.()
+              onBack?.()
             }}
+            disabled={!canBack}
             title="Back"
             className="pw-btn-icon"
+            style={!canBack ? { opacity: 0.4, cursor: 'not-allowed' } : undefined}
           >
             <ChevronLeft size={16} />
           </button>
@@ -80,10 +90,12 @@ export const BrowserPreview: React.FC<BrowserPreviewProps> = ({
               e.preventDefault()
               e.stopPropagation()
               e.nativeEvent.stopImmediatePropagation()
-              ;(window as any).__PYWIRE_PREVIEW_FORWARD__?.()
+              onForward?.()
             }}
+            disabled={!canForward}
             title="Forward"
             className="pw-btn-icon"
+            style={!canForward ? { opacity: 0.4, cursor: 'not-allowed' } : undefined}
           >
             <ChevronRight size={16} />
           </button>

--- a/docs/src/components/tutorial/Preview.tsx
+++ b/docs/src/components/tutorial/Preview.tsx
@@ -371,15 +371,13 @@ export const Preview: React.FC<PreviewProps> = ({ url, onMessage, theme = 'dark'
         const doc = iframeRef.current.contentDocument
         const { processedHtml, isFullDocument, styles } = getProcessedContent(html)
 
-        const pushStateScript = `
-        <script>
-          try {
-            if (window.location.pathname !== "${url}") {
-              window.history.pushState({ pwPath: "${url}" }, "", "${url}");
-            }
-          } catch (e) {}
-        </script>
-      `
+        // Intentionally NOT calling history.pushState here. Same-origin
+        // iframes share the joint session history with the host page,
+        // so pushState entries from this iframe accumulate alongside
+        // parent entries. Calling iframe.history.back() then walks the
+        // joint history and can leak past the iframe into the docs page.
+        // The parent owns the URL stack; we just render content.
+        const pushStateScript = ''
 
         let finalHtml = ''
 
@@ -477,30 +475,9 @@ export const Preview: React.FC<PreviewProps> = ({ url, onMessage, theme = 'dark'
     ;(targetWindow as any).__PYWIRE_PATCH_PREVIEW__ = patchContent
     // Keep this for generic use, map to initContent
     ;(targetWindow as any).__PYWIRE_UPDATE_PREVIEW__ = initContent
-    ;(targetWindow as any).__PYWIRE_PREVIEW_BACK__ = () => {
-      const iframe = iframeRef.current
-      if (iframe && iframe.contentWindow) {
-        const isParentHistory = iframe.contentWindow.history === window.history
-        if (DEBUG_PREVIEW) {
-          console.log('[Preview] Executing iframe history.back()')
-          console.log('[Preview] Is iframe history same as parent?', isParentHistory)
-          console.log('[Preview] Iframe history length:', iframe.contentWindow.history.length)
-        }
-
-        if (!isParentHistory) {
-          iframe.contentWindow.history.back()
-        } else {
-          console.error('[Preview] CRITICAL: Iframe history is identical to parent history!')
-        }
-      }
-    }
-    ;(targetWindow as any).__PYWIRE_PREVIEW_FORWARD__ = () => {
-      const iframe = iframeRef.current
-      if (iframe && iframe.contentWindow) {
-        if (DEBUG_PREVIEW) console.log('[Preview] Executing iframe history.forward()')
-        iframe.contentWindow.history.forward()
-      }
-    }
+    // BACK/FORWARD are owned by BrowserPreview/TutorialWorkspace via a
+    // parent-side url stack. Do NOT expose iframe.history.back() — see
+    // comment in initContent re: joint session history.
     ;(targetWindow as any).__PYWIRE_PREVIEW_RELOAD__ = () => {
       if (DEBUG_PREVIEW) console.log('[Preview] Executing iframe reload (manual HTTP request)')
       window.parent.postMessage(
@@ -528,8 +505,6 @@ export const Preview: React.FC<PreviewProps> = ({ url, onMessage, theme = 'dark'
       delete (targetWindow as any).__PYWIRE_INIT_PREVIEW__
       delete (targetWindow as any).__PYWIRE_PATCH_PREVIEW__
       delete (targetWindow as any).__PYWIRE_UPDATE_PREVIEW__
-      delete (targetWindow as any).__PYWIRE_PREVIEW_BACK__
-      delete (targetWindow as any).__PYWIRE_PREVIEW_FORWARD__
       delete (targetWindow as any).__PYWIRE_PREVIEW_RELOAD__
       delete (targetWindow as any).__PYWIRE_SEND_TO_PREVIEW__
     }

--- a/docs/src/components/tutorial/Preview.tsx
+++ b/docs/src/components/tutorial/Preview.tsx
@@ -418,6 +418,23 @@ export const Preview: React.FC<PreviewProps> = ({ url, onMessage, theme = 'dark'
         `
         }
 
+        // Tear down the prior PyWireApp before rewriting the document.
+        // Without this, the old instance's heartbeat setInterval keeps
+        // ticking on the same iframe window even after doc.write loads a
+        // new <script>. After ~40s of no incoming messages on its old
+        // (now-orphaned) MockWebSocket, it logs "WebSocket heartbeat
+        // timeout, reconnecting", calls socket.close(), and reconnects
+        // with its stored sessionId. Server has no record of that
+        // session → init_ack.session_restored=false → "session expired"
+        // toast. Calling disconnect() clears the heartbeat and sets
+        // shouldReconnect=false on the orphan, killing the loop cleanly.
+        try {
+          const w = iframeRef.current.contentWindow as any
+          w?.PyWireCore?.app?.disconnect?.()
+        } catch (_) {
+          // ignore — fresh iframe with no app yet
+        }
+
         doc.open()
         ;(doc as any).write(finalHtml)
         doc.close()

--- a/docs/src/components/tutorial/TutorialEngine.ts
+++ b/docs/src/components/tutorial/TutorialEngine.ts
@@ -185,6 +185,26 @@ export class TutorialEngine {
     })
   }
 
+  public deleteFile(filename: string) {
+    this.postToWorker({
+      type: 'DELETE_FILE',
+      payload: { filename },
+    })
+  }
+
+  /**
+   * Atomic file-set sync: write all `files` and delete anything else under
+   * `pagesDir`. Used on tutorial step navigation to avoid a full server
+   * restart (which would reset the WS session and trigger the "session
+   * expired" toast).
+   */
+  public syncPages(pagesDir: string, files: Record<string, string>) {
+    this.postToWorker({
+      type: 'SYNC_PAGES',
+      payload: { pagesDir, files },
+    })
+  }
+
   public reset() {
     this.postToWorker({ type: 'RESET' })
   }

--- a/docs/src/components/tutorial/TutorialWorkspace.tsx
+++ b/docs/src/components/tutorial/TutorialWorkspace.tsx
@@ -114,13 +114,44 @@ export const TutorialWorkspace: React.FC<TutorialWorkspaceProps> = ({ initialSlu
     return `${baseUrl}/tutorial/${slug}/`
   }, [])
 
+  // Parent-side history stack for the in-iframe browser. The iframe is
+  // same-origin and shares the joint session history with the host
+  // window, so calling `iframe.contentWindow.history.back()` can leak
+  // past the iframe and navigate the docs page itself. We track URLs
+  // here instead and never touch iframe.history.
+  const [urlStack, setUrlStack] = useState<string[]>([currentStep.initialRoute || '/'])
+  const [urlCursor, setUrlCursor] = useState(0)
+
   const handleNavigate = useCallback(
     (path: string) => {
       setCurrentUrl(path)
+      setUrlStack((prev) => {
+        const truncated = prev.slice(0, urlCursor + 1)
+        if (truncated[truncated.length - 1] === path) return truncated
+        const next = [...truncated, path]
+        setUrlCursor(next.length - 1)
+        return next
+      })
       engineRef.current?.httpRequest('GET', path)
     },
-    [engineRef.current],
+    [engineRef.current, urlCursor],
   )
+
+  const handleBack = useCallback(() => {
+    if (urlCursor <= 0) return
+    const next = urlCursor - 1
+    setUrlCursor(next)
+    setCurrentUrl(urlStack[next])
+    engineRef.current?.httpRequest('GET', urlStack[next])
+  }, [urlCursor, urlStack])
+
+  const handleForward = useCallback(() => {
+    if (urlCursor >= urlStack.length - 1) return
+    const next = urlCursor + 1
+    setUrlCursor(next)
+    setCurrentUrl(urlStack[next])
+    engineRef.current?.httpRequest('GET', urlStack[next])
+  }, [urlCursor, urlStack])
 
   const handlePreviewMessage = useCallback(
     (msg: any) => {
@@ -271,9 +302,13 @@ export const TutorialWorkspace: React.FC<TutorialWorkspaceProps> = ({ initialSlu
 
   // ... (rest of derived state)
 
-  // Update currentUrl when step changes
+  // Update currentUrl when step changes; also reset the in-iframe browser's
+  // history stack so back/forward don't carry across tutorials.
   useEffect(() => {
-    setCurrentUrl(currentStep.initialRoute || '/')
+    const initial = currentStep.initialRoute || '/'
+    setCurrentUrl(initial)
+    setUrlStack([initial])
+    setUrlCursor(0)
   }, [currentStep.slug, currentStep.initialRoute])
 
   // Unified Engine Sync Effect
@@ -281,6 +316,7 @@ export const TutorialWorkspace: React.FC<TutorialWorkspaceProps> = ({ initialSlu
   const lastSyncedSlug = useRef<string | null>(null)
   const lastSyncedUrl = useRef<string | null>(null)
   const lastSyncedFiles = useRef<string | null>(null)
+  const lastSyncedPagesDir = useRef<string | null>(null)
 
   useEffect(() => {
     if (!isReady || !engineRef.current) return
@@ -289,18 +325,29 @@ export const TutorialWorkspace: React.FC<TutorialWorkspaceProps> = ({ initialSlu
     const urlChanged = currentUrl !== lastSyncedUrl.current
     const filesJson = JSON.stringify(debouncedFiles)
     const filesChanged = filesJson !== lastSyncedFiles.current
+    const pagesDir = currentStep.pagesDir || 'pages'
+    const pagesDirChanged = pagesDir !== lastSyncedPagesDir.current
 
     if (slugChanged) {
-      console.log('[TutorialWorkspace] Step Change Reset (RESTART)')
-      engineRef.current.restart(currentStep.pagesDir)
+      // Only do a full RESTART when pagesDir changed (rare). Otherwise
+      // syncPages atomically writes the new file set, deletes leftovers,
+      // and invalidates the loader cache — preserving the WS session so
+      // we don't trigger the "session expired" toast on every step nav.
+      if (pagesDirChanged && lastSyncedPagesDir.current !== null) {
+        console.log('[TutorialWorkspace] Step Change Reset (RESTART, pagesDir changed)')
+        engineRef.current.restart(currentStep.pagesDir)
+        Object.entries(files).forEach(([path, content]) => {
+          engineRef.current?.updateFile(path, content)
+        })
+      } else {
+        console.log('[TutorialWorkspace] Step Change Sync (incremental)')
+        engineRef.current.syncPages(pagesDir, files)
+      }
+
       setActiveFile(currentStep.files[0]?.path || 'index.wire')
       lastSyncedSlug.current = currentStep.slug
-
-      // Push files immediately on step change
-      Object.entries(files).forEach(([path, content]) => {
-        engineRef.current?.updateFile(path, content)
-      })
       lastSyncedFiles.current = JSON.stringify(files)
+      lastSyncedPagesDir.current = pagesDir
 
       // Mark URL as synced as well to prevent double-fire
       lastSyncedUrl.current = currentUrl
@@ -310,10 +357,11 @@ export const TutorialWorkspace: React.FC<TutorialWorkspaceProps> = ({ initialSlu
 
     if (filesChanged) {
       console.log('[TutorialWorkspace] Syncing Files (Debounced)')
-      Object.entries(debouncedFiles).forEach(([path, content]) => {
-        engineRef.current?.updateFile(path, content)
-      })
+      // Use syncPages so newly-added or removed files are picked up the
+      // same way local `pywire dev` does, without restarting the server.
+      engineRef.current.syncPages(pagesDir, debouncedFiles)
       lastSyncedFiles.current = filesJson
+      lastSyncedPagesDir.current = pagesDir
 
       // Reload current URL to reflect changes
       engineRef.current.httpRequest('GET', currentUrl)
@@ -525,6 +573,10 @@ export const TutorialWorkspace: React.FC<TutorialWorkspaceProps> = ({ initialSlu
                   <BrowserPreview
                     url={currentUrl}
                     onNavigate={handleNavigate}
+                    onBack={handleBack}
+                    onForward={handleForward}
+                    canBack={urlCursor > 0}
+                    canForward={urlCursor < urlStack.length - 1}
                     onMessage={handlePreviewMessage}
                     theme={theme}
                   />

--- a/docs/src/pywire-worker.ts
+++ b/docs/src/pywire-worker.ts
@@ -330,6 +330,39 @@ self.onmessage = async (event) => {
     } catch (e) {
       console.error('[Worker] reload_page FAILED:', e)
     }
+  } else if (type === 'DELETE_FILE') {
+    const path = `/app/${payload.filename}`
+    console.log('[Worker] DELETE_FILE:', path)
+    try {
+      pyodide!.globals.get('delete_file')(path)
+    } catch (e) {
+      console.error('[Worker] delete_file FAILED:', e)
+    }
+  } else if (type === 'SYNC_PAGES') {
+    const { pagesDir, files } = payload || {}
+    console.log('[Worker] SYNC_PAGES:', pagesDir, Object.keys(files || {}))
+
+    // Ensure parent directories for all incoming files exist (sync_pages
+    // calls os.makedirs but Pyodide FS can be flakey — pre-create the way
+    // UPDATE_FILE does).
+    for (const rel of Object.keys(files || {})) {
+      const full = `/app/${rel}`
+      const dir = full.substring(0, full.lastIndexOf('/'))
+      const parts = dir.split('/').filter(Boolean)
+      let current = ''
+      for (const part of parts) {
+        current += `/${part}`
+        if (!pyodide!.FS.analyzePath(current).exists) {
+          pyodide!.FS.mkdir(current)
+        }
+      }
+    }
+
+    try {
+      pyodide!.globals.get('sync_pages')(pagesDir || 'pages', pyodide!.toPy(files || {}))
+    } catch (e) {
+      console.error('[Worker] sync_pages FAILED:', e)
+    }
   } else if (type === 'RESTART') {
     console.log('[Worker] Restarting pywire server...')
     const { pagesDir } = payload || {}


### PR DESCRIPTION
## Summary

Two layers of zombies were spamming the console after a few minutes / a few step navs in the tutorial:

1. **Client side (commit 1, `Preview.tsx`):** every `doc.open()/write()` left the prior `PyWireApp` instance alive on the same iframe window. Its heartbeat `setInterval` kept ticking on a now-orphaned `MockWebSocket`, eventually firing `heartbeat timeout, reconnecting` and reconnecting with its stored `sessionId`. Server didn't recognize → `init_ack.session_restored=false` → "session expired" toast. Fix: call `PyWireCore.app.disconnect()` before `doc.write()`.

2. **Server side (commit 2, all four files):** `MockWebSocket.close()` never told the worker about the disconnect, so each preview rebuild left the prior ASGI WebSocket alive in the in-Pyodide PyWire router. The router's per-connection `ping_loop` kept running on each zombie, eventually firing `WebSocket ping timeout, closing connection` for each one. They accumulated per refresh / step nav. Fix: route `MockWebSocket.close()` through a new `WS_DISCONNECT` postMessage → `TutorialWorkspace` → `TutorialEngine.wsDisconnect()` → worker → `shim.handle_js_message` `ws_disconnect` event → `adp.ws_close(connection_id)`. Also have `ws_connect` close any prior connection mapped to the same `req_id` as defense-in-depth.

## Test plan

- [ ] Spam-click refresh: no "session expired" toast, no "WebSocket heartbeat timeout" warning.
- [ ] Open a tutorial step, leave it for 2+ minutes: no "WebSocket ping timeout, closing connection" lines accumulating.
- [ ] Navigate through 5+ tutorial steps over a few minutes: warning count stays flat (one per real disconnect, not one per step).
- [ ] Live editing of `.wire` files: each save triggers a doc rebuild via the same path; verify only one PyWireApp + one server-side WS alive at a time.