### PR TITLE
fix(pywire-docs): tear down server-side WS on iframe doc.write

### DIFF
--- a/docs/public/shim.py
+++ b/docs/public/shim.py
@@ -96,14 +96,22 @@ async def handle_js_message(event_data):
                     path = path[slash_idx:]
 
             # Cancel any orphaned forward task from a previous WS connection
-            # before starting a new one. The previous connection's WebSocketRouter
-            # ping loop is cleaned up either by restart_server (step nav) or by
-            # the framework's own disconnect handler when the underlying socket
-            # ultimately closes — we don't tear it down here to avoid racing
-            # the new connection's setup.
+            # before starting a new one. Also close the prior server-side
+            # WebSocket bound to this req_id so its ping_loop is cancelled
+            # and we don't accumulate zombie connections on each preview
+            # rebuild (doc.write inside the iframe makes new MockWS without
+            # the old one ever sending its disconnect).
             for _t in list(getattr(handle_js_message, "_ws_tasks", [])):
                 _t.cancel()
             handle_js_message._ws_tasks = []
+            id_map = getattr(handle_js_message, "_id_map", {}) or {}
+            prior_cid = id_map.pop(req_id, None)
+            if prior_cid is not None:
+                try:
+                    await adp.ws_close(prior_cid)
+                except Exception as e:
+                    print(f"ws_close (prior) failed for {prior_cid}: {e}")
+            handle_js_message._id_map = id_map
 
             connection_id = await adp.ws_connect(path=path)
             if not hasattr(handle_js_message, "_id_map"):
@@ -142,6 +150,27 @@ async def handle_js_message(event_data):
 
             fwd_task = asyncio.create_task(forward_ws_messages())
             handle_js_message._ws_tasks = [fwd_task]
+
+        elif event_type == "ws_disconnect":
+            # Iframe's MockWebSocket told us its close() ran (typically
+            # because the parent is about to doc.write a fresh document).
+            # Tear down the server-side ASGI WebSocket so its ping_loop
+            # is cancelled and we don't accumulate zombie connections
+            # whose periodic ping timeouts spam the console.
+            adp = get_adapter()
+            id_map = getattr(handle_js_message, "_id_map", {})
+            connection_id = id_map.pop(req_id, None)
+            if connection_id:
+                try:
+                    await adp.ws_close(connection_id)
+                except Exception as e:
+                    print(f"ws_close failed for {connection_id}: {e}")
+            # Also cancel any stale forwarders we still hold for this
+            # connection so we don't leak the asyncio task.
+            for _t in list(getattr(handle_js_message, "_ws_tasks", [])):
+                if not _t.done():
+                    _t.cancel()
+            handle_js_message._ws_tasks = []
 
         elif event_type == "ws_send":
             adp = get_adapter()

--- a/docs/src/components/tutorial/Preview.tsx
+++ b/docs/src/components/tutorial/Preview.tsx
@@ -109,6 +109,15 @@ const INJECTED_SCRIPT = `
     close() {
       if (DEBUG_PREVIEW) console.log('[MockWS] WebSocket closed');
       this.readyState = 3; // CLOSED
+      // Notify parent so it can tear down the server-side connection in
+      // the Pyodide adapter. Without this, each iframe doc.write leaves
+      // a zombie ASGI WebSocket alive in the in-Pyodide PyWire app
+      // whose ping_loop keeps running and eventually logs
+      // 'WebSocket ping timeout, closing connection'. They accumulate
+      // and starve real connections.
+      try {
+        window.parent.postMessage({ type: 'WS_DISCONNECT', payload: {} }, '*');
+      } catch (_) {}
       this.dispatchEvent(new Event('close'));
       if (this.onclose) this.onclose(new Event('close'));
     }

--- a/docs/src/components/tutorial/TutorialEngine.ts
+++ b/docs/src/components/tutorial/TutorialEngine.ts
@@ -255,4 +255,19 @@ export class TutorialEngine {
       },
     })
   }
+
+  /**
+   * Tear down the server-side WebSocket bound to the current iframe doc.
+   * Sent by the iframe's MockWebSocket.close() so the in-Pyodide PyWire
+   * router can cancel its ping_loop and free resources.
+   */
+  public wsDisconnect() {
+    this.postToWorker({
+      type: 'REQUEST',
+      payload: {
+        type: 'ws_disconnect',
+        id: 'ws-main',
+      },
+    })
+  }
 }

--- a/docs/src/components/tutorial/TutorialWorkspace.tsx
+++ b/docs/src/components/tutorial/TutorialWorkspace.tsx
@@ -163,6 +163,9 @@ export const TutorialWorkspace: React.FC<TutorialWorkspaceProps> = ({ initialSlu
         case 'WS_SEND':
           engineRef.current.wsSend(msg.payload.data)
           break
+        case 'WS_DISCONNECT':
+          engineRef.current.wsDisconnect()
+          break
         case 'HTTP_REQUEST':
           engineRef.current.httpRequest(msg.payload.method, msg.payload.path, msg.payload.headers)
           break


### PR DESCRIPTION
## Summary

Fixes the actual root cause of the "WebSocket heartbeat timeout, reconnecting…" + duplicate accept/init flood seen during edits in the tutorial. The previous fix attempt (now superseded by the second commit on this branch) was incomplete — the underlying leak was forwarder accumulation in the shim.

## Diagnosis

User reported logs showing N copies of \`websocket.accept\` + \`PyWire Client v0.14.2 • Server v0.14.2\` + \`PyWire: Application ready\` after the Nth edit cycle, growing by one each time. Tracing it:

- Every iframe \`doc.write()\` ends with a new \`MockWebSocket\` posting \`WS_CONNECT\`. Same \`req_id="ws-main"\` every time.
- Shim's \`ws_connect\` previously stored the forwarder task in a single-element list \`_ws_tasks\` that was overwritten on every new connect. The reference to earlier forwarders was lost — they couldn't be cancelled.
- Each forwarder is blocked in \`await adp.ws_receive(connection_id)\` (which awaits \`send_queue.get()\`). \`adp.ws_close\` only puts a sentinel in the **receive** queue, not the send queue, so the forwarder stays blocked indefinitely.
- N forwarders alive → every server-side message gets posted to JS N times under the same \`req_id="ws-main"\` → MockWebSocket dispatches N \`onmessage\` callbacks → PyWire client sees N init_acks → toast / Application-ready spam.
- Many duplicate pongs racing one heartbeat path also tripped the heartbeat timeout occasionally.

## Fix

- Shim: track forwarders in a \`{req_id: Task}\` dict (\`_fwd_tasks\`). On a new \`ws_connect\` for the same \`req_id\`, cancel the prior task. Forwarder's \`except asyncio.CancelledError\` swallows it cleanly.
- Same cleanup on \`ws_disconnect\` and \`restart_server\`.
- Parent: fire \`engineRef.current.wsDisconnect()\` from \`onResponse\` **before** \`__PYWIRE_INIT_PREVIEW__\` rewrites the iframe document. This guarantees the prior server-side WS gets torn down regardless of whether the iframe-side \`PyWireCore.app.disconnect()\` path actually fired (e.g. on first paint or if the prior init hadn't finished loading).

## Test plan

- [ ] Edit code in the editor 10+ times. Each cycle's \`onResponse\` shows exactly one \`websocket.accept\` and one \`Application ready\`, not N.
- [ ] Leave a step idle for 2+ minutes after several edits. No \`WebSocket heartbeat timeout\` warning, no \`session expired\` toast.
- [ ] Step navigation through 5+ steps. No accumulation; warning count stays flat.