### PR TITLE
fix(pywire-docs): replace iframe element to kill stale heartbeat timers

### DIFF
--- a/docs/src/components/tutorial/Preview.tsx
+++ b/docs/src/components/tutorial/Preview.tsx
@@ -297,7 +297,8 @@ const getStylesInner = (theme: 'light' | 'dark') => `
 `
 
 export const Preview: React.FC<PreviewProps> = ({ url, onMessage, theme = 'dark' }) => {
-  const iframeRef = useRef<HTMLIFrameElement>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const iframeRef = useRef<HTMLIFrameElement | null>(null)
 
   useEffect(() => {
     const handleMessage = (event: MessageEvent) => {
@@ -327,6 +328,30 @@ export const Preview: React.FC<PreviewProps> = ({ url, onMessage, theme = 'dark'
   useEffect(() => {
     isInitialized.current = false
   }, [url])
+
+  // Replace the iframe element with a fresh one. Critical: doc.open()/write()
+  // does NOT reset the iframe's window object — globals, including setInterval
+  // timers from prior PyWireApp instances created by re-running the bundled
+  // IIFE script tag, persist forever. Each edit cycle leaks another live
+  // heartbeat timer; eventually one of them times out, triggering reconnects
+  // and the "session expired" UX. Replacing the <iframe> element gives a
+  // brand-new window and kills all stale timers in one shot.
+  const replaceIframe = useCallback((): HTMLIFrameElement | null => {
+    const container = containerRef.current
+    if (!container) return null
+    const old = iframeRef.current
+    const next = document.createElement('iframe')
+    next.style.width = '100%'
+    next.style.height = '100%'
+    next.style.border = 'none'
+    next.title = 'Preview'
+    container.appendChild(next)
+    if (old && old.parentNode === container) {
+      container.removeChild(old)
+    }
+    iframeRef.current = next
+    return next
+  }, [])
 
   // Helper to get processed HTML and styles
   const getProcessedContent = useCallback(
@@ -375,9 +400,10 @@ export const Preview: React.FC<PreviewProps> = ({ url, onMessage, theme = 'dark'
   // This creates a fresh document with new MockWebSocket connection
   const initContent = useCallback(
     (html: string) => {
-      if (DEBUG_PREVIEW) console.log('[Preview] initContent called (full doc.write)')
-      if (iframeRef.current && iframeRef.current.contentDocument) {
-        const doc = iframeRef.current.contentDocument
+      if (DEBUG_PREVIEW) console.log('[Preview] initContent called (replace iframe)')
+      const iframe = replaceIframe()
+      if (iframe && iframe.contentDocument) {
+        const doc = iframe.contentDocument
         const { processedHtml, isFullDocument, styles } = getProcessedContent(html)
 
         // Intentionally NOT calling history.pushState here. Same-origin
@@ -427,30 +453,13 @@ export const Preview: React.FC<PreviewProps> = ({ url, onMessage, theme = 'dark'
         `
         }
 
-        // Tear down the prior PyWireApp before rewriting the document.
-        // Without this, the old instance's heartbeat setInterval keeps
-        // ticking on the same iframe window even after doc.write loads a
-        // new <script>. After ~40s of no incoming messages on its old
-        // (now-orphaned) MockWebSocket, it logs "WebSocket heartbeat
-        // timeout, reconnecting", calls socket.close(), and reconnects
-        // with its stored sessionId. Server has no record of that
-        // session → init_ack.session_restored=false → "session expired"
-        // toast. Calling disconnect() clears the heartbeat and sets
-        // shouldReconnect=false on the orphan, killing the loop cleanly.
-        try {
-          const w = iframeRef.current.contentWindow as any
-          w?.PyWireCore?.app?.disconnect?.()
-        } catch (_) {
-          // ignore — fresh iframe with no app yet
-        }
-
         doc.open()
         ;(doc as any).write(finalHtml)
         doc.close()
         isInitialized.current = true
       }
     },
-    [url, theme, getProcessedContent],
+    [url, theme, getProcessedContent, replaceIframe],
   )
 
   // patchContent: Incremental update via innerHTML (used for WebSocket updates)
@@ -536,13 +545,5 @@ export const Preview: React.FC<PreviewProps> = ({ url, onMessage, theme = 'dark'
     }
   }, [url, initContent, patchContent])
 
-  return (
-    <div style={{ height: '100%', width: '100%', overflow: 'hidden' }}>
-      <iframe
-        ref={iframeRef}
-        style={{ width: '100%', height: '100%', border: 'none' }}
-        title="Preview"
-      />
-    </div>
-  )
+  return <div ref={containerRef} style={{ height: '100%', width: '100%', overflow: 'hidden' }} />
 }


### PR DESCRIPTION
## Summary

Even after #214, edit cycles still leak heartbeat timers and produce reconnect storms. Root cause: `doc.open()/write()` rewrites the iframe document but does **not** reset its `window`. The bundled pywire client (`pywire.core.min.js`) is an IIFE — each `<script>` tag execution creates a **new** `PyWireApp` with its own `setInterval` heartbeat. Old instances stay alive on the same iframe window. `PyWireCore.app.disconnect()` only stops the latest singleton; older leaked apps keep ticking.

After ~40s of silence on its now-orphaned MockWebSocket, each leaked heartbeat fires `WebSocket heartbeat timeout, reconnecting`, opens a fresh `ws_connect` carrying a stored `sessionId` the server doesn't know, triggers reconnect storms, and lands the "session expired" UX. Logs show the warning originating from old VM contexts (e.g. `VM2163`) long after their iframe document was replaced — confirming the leak.

Fix: replace the `<iframe>` element entirely on each `initContent`. Fresh window, all stale timers and leaked `PyWireApp` instances drop with it.

## Test plan
- [ ] Edit `pages/index.wire` repeatedly for several minutes; no `WebSocket heartbeat timeout` warnings
- [ ] Step nav across multiple tutorial steps; no session-expired toast
- [ ] Each edit cycle emits exactly one `websocket.accept` and one `Application ready`
- [ ] Iframe back/forward still work