### PR TITLE
fix(pywire-docs): hard-disconnect WS in shim to cancel framework ping_loop

### DIFF
--- a/docs/public/shim.py
+++ b/docs/public/shim.py
@@ -46,6 +46,34 @@ def get_adapter():
     return adapter
 
 
+def _hard_disconnect(adp, connection_id):
+    """Force the framework's WebSocketRouter cleanup to actually run.
+
+    `adp.ws_close()` only signals the receive_queue; it does NOT cancel
+    the per-connection `_ping_loop` task that PyWire spawns inside
+    WebSocketRouter. That task lives on the framework side, sleeps for
+    25s, sends a ping, sleeps 10s waiting for a pong — and if the iframe
+    document was already replaced, no pong arrives, so the ping_loop
+    logs "WebSocket ping timeout, closing connection" and forcibly
+    closes the (already-orphaned) ASGI socket. Each iframe replace
+    leaves another ping_loop running in the background; eventually one
+    fires its timeout and triggers the visible reconnect storm.
+
+    Putting `websocket.disconnect` directly into the receive queue lets
+    the framework's own receive() inside _ping_loop wake up, see the
+    disconnect, and exit cleanly. We also pop both queues so the
+    connection's state is fully gone before the next ws_connect.
+    """
+    try:
+        q = adp._ws_connections.get(connection_id)
+        if q is not None:
+            q.put_nowait({"type": "websocket.disconnect", "code": 1000})
+        adp._ws_connections.pop(connection_id, None)
+        adp._ws_connections.pop(f"{connection_id}_send", None)
+    except Exception as e:
+        print(f"_hard_disconnect failed for {connection_id}: {e}")
+
+
 async def handle_js_message(event_data):
     """Route incoming JS messages to the adapter."""
     try:
@@ -117,10 +145,7 @@ async def handle_js_message(event_data):
             id_map = getattr(handle_js_message, "_id_map", {}) or {}
             prior_cid = id_map.pop(req_id, None)
             if prior_cid is not None:
-                try:
-                    await adp.ws_close(prior_cid)
-                except Exception as e:
-                    print(f"ws_close (prior) failed for {prior_cid}: {e}")
+                _hard_disconnect(adp, prior_cid)
 
             connection_id = await adp.ws_connect(path=path)
             id_map[req_id] = connection_id
@@ -176,10 +201,7 @@ async def handle_js_message(event_data):
             connection_id = id_map.pop(req_id, None)
             handle_js_message._id_map = id_map
             if connection_id:
-                try:
-                    await adp.ws_close(connection_id)
-                except Exception as e:
-                    print(f"ws_close failed for {connection_id}: {e}")
+                _hard_disconnect(adp, connection_id)
             fwd_tasks = getattr(handle_js_message, "_fwd_tasks", None) or {}
             fwd_task = fwd_tasks.pop(req_id, None)
             if fwd_task is not None and not fwd_task.done():

--- a/docs/src/components/tutorial/Preview.tsx
+++ b/docs/src/components/tutorial/Preview.tsx
@@ -297,7 +297,8 @@ const getStylesInner = (theme: 'light' | 'dark') => `
 `
 
 export const Preview: React.FC<PreviewProps> = ({ url, onMessage, theme = 'dark' }) => {
-  const iframeRef = useRef<HTMLIFrameElement>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const iframeRef = useRef<HTMLIFrameElement | null>(null)
 
   useEffect(() => {
     const handleMessage = (event: MessageEvent) => {
@@ -327,6 +328,30 @@ export const Preview: React.FC<PreviewProps> = ({ url, onMessage, theme = 'dark'
   useEffect(() => {
     isInitialized.current = false
   }, [url])
+
+  // Replace the iframe element with a fresh one. Critical: doc.open()/write()
+  // does NOT reset the iframe's window object — globals, including setInterval
+  // timers from prior PyWireApp instances created by re-running the bundled
+  // IIFE script tag, persist forever. Each edit cycle leaks another live
+  // heartbeat timer; eventually one of them times out, triggering reconnects
+  // and the "session expired" UX. Replacing the <iframe> element gives a
+  // brand-new window and kills all stale timers in one shot.
+  const replaceIframe = useCallback((): HTMLIFrameElement | null => {
+    const container = containerRef.current
+    if (!container) return null
+    const old = iframeRef.current
+    const next = document.createElement('iframe')
+    next.style.width = '100%'
+    next.style.height = '100%'
+    next.style.border = 'none'
+    next.title = 'Preview'
+    container.appendChild(next)
+    if (old && old.parentNode === container) {
+      container.removeChild(old)
+    }
+    iframeRef.current = next
+    return next
+  }, [])
 
   // Helper to get processed HTML and styles
   const getProcessedContent = useCallback(
@@ -375,9 +400,10 @@ export const Preview: React.FC<PreviewProps> = ({ url, onMessage, theme = 'dark'
   // This creates a fresh document with new MockWebSocket connection
   const initContent = useCallback(
     (html: string) => {
-      if (DEBUG_PREVIEW) console.log('[Preview] initContent called (full doc.write)')
-      if (iframeRef.current && iframeRef.current.contentDocument) {
-        const doc = iframeRef.current.contentDocument
+      if (DEBUG_PREVIEW) console.log('[Preview] initContent called (replace iframe)')
+      const iframe = replaceIframe()
+      if (iframe && iframe.contentDocument) {
+        const doc = iframe.contentDocument
         const { processedHtml, isFullDocument, styles } = getProcessedContent(html)
 
         // Intentionally NOT calling history.pushState here. Same-origin
@@ -427,30 +453,13 @@ export const Preview: React.FC<PreviewProps> = ({ url, onMessage, theme = 'dark'
         `
         }
 
-        // Tear down the prior PyWireApp before rewriting the document.
-        // Without this, the old instance's heartbeat setInterval keeps
-        // ticking on the same iframe window even after doc.write loads a
-        // new <script>. After ~40s of no incoming messages on its old
-        // (now-orphaned) MockWebSocket, it logs "WebSocket heartbeat
-        // timeout, reconnecting", calls socket.close(), and reconnects
-        // with its stored sessionId. Server has no record of that
-        // session → init_ack.session_restored=false → "session expired"
-        // toast. Calling disconnect() clears the heartbeat and sets
-        // shouldReconnect=false on the orphan, killing the loop cleanly.
-        try {
-          const w = iframeRef.current.contentWindow as any
-          w?.PyWireCore?.app?.disconnect?.()
-        } catch (_) {
-          // ignore — fresh iframe with no app yet
-        }
-
         doc.open()
         ;(doc as any).write(finalHtml)
         doc.close()
         isInitialized.current = true
       }
     },
-    [url, theme, getProcessedContent],
+    [url, theme, getProcessedContent, replaceIframe],
   )
 
   // patchContent: Incremental update via innerHTML (used for WebSocket updates)
@@ -536,13 +545,5 @@ export const Preview: React.FC<PreviewProps> = ({ url, onMessage, theme = 'dark'
     }
   }, [url, initContent, patchContent])
 
-  return (
-    <div style={{ height: '100%', width: '100%', overflow: 'hidden' }}>
-      <iframe
-        ref={iframeRef}
-        style={{ width: '100%', height: '100%', border: 'none' }}
-        title="Preview"
-      />
-    </div>
-  )
+  return <div ref={containerRef} style={{ height: '100%', width: '100%', overflow: 'hidden' }} />
 }


### PR DESCRIPTION
## Summary

After #214 and #216, fast edit cycles are clean for the first ~20 iterations, but a step nav (or enough time elapsing) eventually surfaces \`WebSocket ping timeout, closing connection\` from the **Python** side (PyWire's per-connection \`_ping_loop\` in WebSocketRouter), followed by the visible reconnect storm.

Root cause: \`adp.ws_close()\` only signals the receive_queue's read path; it does **not** cancel the framework-side \`_ping_loop\` task spawned per connection. That task does \`sleep(25)\` → ping → \`sleep(10)\` → pong-or-timeout. Each iframe replace leaves another live \`_ping_loop\` in the background; eventually one fires its timeout and forcibly closes the (already-orphaned) ASGI socket, which triggers the client to reconnect.

\`restart_server\` already had the working recipe — push \`websocket.disconnect\` into the connection's receive_queue so the framework's own \`receive()\` inside \`_ping_loop\` wakes up, sees the disconnect, and exits. But \`ws_disconnect\` and the prior-cid cleanup inside \`ws_connect\` both took the weaker \`adp.ws_close()\` path. Extract the recipe as \`_hard_disconnect\` and apply everywhere a WS is torn down.

## Test plan
- [ ] Edit \`pages/index.wire\` for several minutes; no \`WebSocket ping timeout, closing connection\` from the Python side
- [ ] Step nav across several tutorials, then keep editing; no reconnect storm, no stale UI
- [ ] Each edit emits exactly one \`websocket.accept\`, one \`Application ready\`