### PR TITLE
fix(pywire-docs): disable ws ping_loop in shim — both ends are in-browser

### DIFF
--- a/docs/public/shim.py
+++ b/docs/public/shim.py
@@ -35,7 +35,18 @@ def get_adapter():
                 sys.path.insert(0, project_root)
 
             print(f"Initializing PyWire app with pages_dir={current_pages_dir}...")
-            app_instance = PyWire(pages_dir=current_pages_dir, debug=True)
+            # ws_ping_interval=0 disables the framework's per-connection
+            # _ping_loop. Both ends of this WebSocket live in the same
+            # browser tab (iframe ↔ Pyodide worker via postMessage); there
+            # is no network to monitor. Under load (e.g. validate() firing
+            # many fetchRouteContent → http_request through the worker
+            # serially), the pong from the iframe queues up behind the
+            # http_requests and misses the 10s pong-deadline → the
+            # framework forcibly closes a perfectly healthy connection
+            # and triggers a reconnect storm.
+            app_instance = PyWire(
+                pages_dir=current_pages_dir, debug=True, ws_ping_interval=0
+            )
             app_instance._is_dev_mode = True
             adapter = PyodideASGIAdapter(app_instance)
             print("PyWire app initialized successfully")


### PR DESCRIPTION
## Summary

After the prior fixes (#214 #216 #219), edits stay clean for many cycles, but a single long-lived WS connection (no iframe replacement, no accumulated state) eventually trips \`WebSocket ping timeout, closing connection\` from the **framework** itself, followed by the visible reconnect storm.

Pyodide is single-threaded and processes worker messages serially. When the tutorial's validate() fires a burst of \`fetchRouteContent → http_request\` through the worker, a pong from the iframe queues up behind those http_requests and misses the framework's 10s pong-deadline. The framework forcibly closes a healthy connection.

Both ends of this WebSocket live in the same browser tab (iframe MockWebSocket ↔ Pyodide via \`postMessage\`). There is no network in between — there is nothing for keep-alive ping/pong to detect. Pass \`ws_ping_interval=0\` when constructing the in-Pyodide \`PyWire\` app to disable \`_ping_loop\` entirely.

## Test plan
- [ ] Edit a page for several minutes under heavy validate() activity; no \`WebSocket ping timeout\` warnings, no reconnect storms
- [ ] Step nav repeatedly; same
- [ ] Single \`websocket.accept\` and \`Application ready\` per edit cycle