### PR TITLE
fix(pywire-docs): keep client WS alive + state-preserving HMR

### DIFF
--- a/docs/public/shim.py
+++ b/docs/public/shim.py
@@ -368,6 +368,16 @@ def sync_pages(pages_dir, files):
                     adapter.app.reload_page(pathlib.Path(p))
                 except Exception:
                     pass
+            # Mirror native `pywire dev` HMR: broadcast a state-preserving
+            # reload to active WS clients so the iframe re-renders against
+            # the updated code without losing component/page state. Without
+            # this, edits only show up after a full navigation/refresh.
+            try:
+                ws_handler = getattr(adapter.app, "ws_handler", None)
+                if ws_handler is not None:
+                    asyncio.ensure_future(ws_handler.broadcast_reload())
+            except Exception as e:
+                print(f"broadcast_reload failed: {e}")
         return True
     except Exception as e:
         print(f"sync_pages failed: {e}")

--- a/docs/src/components/tutorial/Preview.tsx
+++ b/docs/src/components/tutorial/Preview.tsx
@@ -35,6 +35,21 @@ const INJECTED_SCRIPT = `
       this._onmessage = null;
       this._onclose = null;
       this._onerror = null;
+      this._keepaliveTimer = null;
+
+      // PyWire client-side heartbeat (websocket.ts) closes the socket if
+      // 40s pass with no inbound message. Server-side _ping_loop is
+      // disabled in shim.py (ws_ping_interval=0) because under Pyodide's
+      // single-thread, pong from the iframe gets starved behind
+      // http_request bursts and trips the 10s pong-deadline → forced
+      // close → reconnect storm. With server pings off, nothing else
+      // refreshes lastMessageTime on the client, so an idle session
+      // disconnects after 40s. Synthesize a self-ping inside the iframe:
+      // the client transport handles type:'ping' by responding pong
+      // (server pong handler is a noop with ping_loop off) and, more
+      // importantly, refreshes lastMessageTime on the inbound path.
+      // Bytes are msgpack({type:'ping'}) precomputed.
+      const PING_BYTES = new Uint8Array([0x81, 0xa4, 0x74, 0x79, 0x70, 0x65, 0xa4, 0x70, 0x69, 0x6e, 0x67]);
 
       // Notify parent we want to connect
       window.parent.postMessage({
@@ -54,6 +69,14 @@ const INJECTED_SCRIPT = `
              if (this.onopen) {
                if (DEBUG_PREVIEW) console.log('[MockWS] Calling onopen handler');
                this.onopen(new Event('open'));
+             }
+             if (this._keepaliveTimer === null) {
+               this._keepaliveTimer = setInterval(() => {
+                 if (this.readyState !== 1) return;
+                 const ev = new MessageEvent('message', { data: PING_BYTES.buffer.slice(0) });
+                 this.dispatchEvent(ev);
+                 if (this.onmessage) this.onmessage(ev);
+               }, 15000);
              }
           }
           if (e.data.message.type === 'websocket.send') {
@@ -75,6 +98,10 @@ const INJECTED_SCRIPT = `
           if (e.data.message.type === 'websocket.close') {
              if (DEBUG_PREVIEW) console.log('[MockWS] WebSocket closed by server');
              this.readyState = 3; // CLOSED
+             if (this._keepaliveTimer !== null) {
+               clearInterval(this._keepaliveTimer);
+               this._keepaliveTimer = null;
+             }
              this.dispatchEvent(new Event('close'));
              if (this.onclose) this.onclose(new Event('close'));
           }
@@ -109,6 +136,10 @@ const INJECTED_SCRIPT = `
     close() {
       if (DEBUG_PREVIEW) console.log('[MockWS] WebSocket closed');
       this.readyState = 3; // CLOSED
+      if (this._keepaliveTimer !== null) {
+        clearInterval(this._keepaliveTimer);
+        this._keepaliveTimer = null;
+      }
       // Notify parent so it can tear down the server-side connection in
       // the Pyodide adapter. Without this, each iframe doc.write leaves
       // a zombie ASGI WebSocket alive in the in-Pyodide PyWire app


### PR DESCRIPTION
## Summary

Two bugs in the docs tutorial preview, fixed together because they share the same root cause area (in-browser WS bridge + Pyodide single-threadedness).

### 1. Idle disconnect

Symptom: after typical tutorial usage (solve, type, next, prev, reset, type…) the client logs `WebSocket heartbeat timeout, reconnecting…` followed by a reconnect storm.

Root cause: PR #221 disabled the framework's per-connection `_ping_loop` (`ws_ping_interval=0`) because Pyodide's single thread starves the pong-delivery path under `validate()` http_request bursts and trips the 10s pong-deadline. But the **client** transport (`packages/pywire/src/pywire/client/src/core/transports/websocket.ts`) has its own 40s heartbeat that closes the socket if no inbound message arrives. With server pings off, nothing refreshes `lastMessageTime`, so an idle session disconnects.

Fix: synthesize a self-ping inside the iframe's `MockWebSocket` every 15s. Bytes are precomputed `msgpack({type:'ping'})`. The PyWire client transport already handles inbound `ping` (refreshes `lastMessageTime`, replies pong); the server's pong handler is a benign noop with `_ping_loop` disabled. Cleared on `close()` and on `websocket.close` so it doesn't leak across iframe replaces.

### 2. No HMR (state preservation)

Symptom: editing code reloads the file on the server but the iframe doesn't re-render until the user navigates.

Root cause: `sync_pages` invalidates the loader cache via `app.reload_page(p)` but never tells active WS clients to re-render.

Fix: mirror native `pywire dev` by calling `ws_handler.broadcast_reload()` after the per-file `reload_page` loop. That helper already migrates page+component state to the new module's class.

## Test plan

- [ ] Deploy + reload pywire.dev tutorial
- [ ] Idle a step ~60s — no `heartbeat timeout` warning, no reconnect overlay
- [ ] Run through solve/next/prev/reset/type cycle several times — no disconnect
- [ ] Edit `pages/index.wire` while the preview shows non-trivial state (e.g. counter incremented) — preview re-renders showing edits with state preserved