### PR TITLE
fix(pywire-docs): round-2 tutorial followups

### DIFF
--- a/docs/public/shim.py
+++ b/docs/public/shim.py
@@ -368,6 +368,16 @@ def sync_pages(pages_dir, files):
                     adapter.app.reload_page(pathlib.Path(p))
                 except Exception:
                     pass
+            # Mirror native `pywire dev` HMR: broadcast a state-preserving
+            # reload to active WS clients so the iframe re-renders against
+            # the updated code without losing component/page state. Without
+            # this, edits only show up after a full navigation/refresh.
+            try:
+                ws_handler = getattr(adapter.app, "ws_handler", None)
+                if ws_handler is not None:
+                    asyncio.ensure_future(ws_handler.broadcast_reload())
+            except Exception as e:
+                print(f"broadcast_reload failed: {e}")
         return True
     except Exception as e:
         print(f"sync_pages failed: {e}")

--- a/docs/src/components/tutorial/Preview.tsx
+++ b/docs/src/components/tutorial/Preview.tsx
@@ -35,6 +35,21 @@ const INJECTED_SCRIPT = `
       this._onmessage = null;
       this._onclose = null;
       this._onerror = null;
+      this._keepaliveTimer = null;
+
+      // PyWire client-side heartbeat (websocket.ts) closes the socket if
+      // 40s pass with no inbound message. Server-side _ping_loop is
+      // disabled in shim.py (ws_ping_interval=0) because under Pyodide's
+      // single-thread, pong from the iframe gets starved behind
+      // http_request bursts and trips the 10s pong-deadline → forced
+      // close → reconnect storm. With server pings off, nothing else
+      // refreshes lastMessageTime on the client, so an idle session
+      // disconnects after 40s. Synthesize a self-ping inside the iframe:
+      // the client transport handles type:'ping' by responding pong
+      // (server pong handler is a noop with ping_loop off) and, more
+      // importantly, refreshes lastMessageTime on the inbound path.
+      // Bytes are msgpack({type:'ping'}) precomputed.
+      const PING_BYTES = new Uint8Array([0x81, 0xa4, 0x74, 0x79, 0x70, 0x65, 0xa4, 0x70, 0x69, 0x6e, 0x67]);
 
       // Notify parent we want to connect
       window.parent.postMessage({
@@ -54,6 +69,14 @@ const INJECTED_SCRIPT = `
              if (this.onopen) {
                if (DEBUG_PREVIEW) console.log('[MockWS] Calling onopen handler');
                this.onopen(new Event('open'));
+             }
+             if (this._keepaliveTimer === null) {
+               this._keepaliveTimer = setInterval(() => {
+                 if (this.readyState !== 1) return;
+                 const ev = new MessageEvent('message', { data: PING_BYTES.buffer.slice(0) });
+                 this.dispatchEvent(ev);
+                 if (this.onmessage) this.onmessage(ev);
+               }, 15000);
              }
           }
           if (e.data.message.type === 'websocket.send') {
@@ -75,6 +98,10 @@ const INJECTED_SCRIPT = `
           if (e.data.message.type === 'websocket.close') {
              if (DEBUG_PREVIEW) console.log('[MockWS] WebSocket closed by server');
              this.readyState = 3; // CLOSED
+             if (this._keepaliveTimer !== null) {
+               clearInterval(this._keepaliveTimer);
+               this._keepaliveTimer = null;
+             }
              this.dispatchEvent(new Event('close'));
              if (this.onclose) this.onclose(new Event('close'));
           }
@@ -109,6 +136,10 @@ const INJECTED_SCRIPT = `
     close() {
       if (DEBUG_PREVIEW) console.log('[MockWS] WebSocket closed');
       this.readyState = 3; // CLOSED
+      if (this._keepaliveTimer !== null) {
+        clearInterval(this._keepaliveTimer);
+        this._keepaliveTimer = null;
+      }
       // Notify parent so it can tear down the server-side connection in
       // the Pyodide adapter. Without this, each iframe doc.write leaves
       // a zombie ASGI WebSocket alive in the in-Pyodide PyWire app

--- a/docs/src/components/tutorial/SuccessValidator.ts
+++ b/docs/src/components/tutorial/SuccessValidator.ts
@@ -16,6 +16,7 @@ export class SuccessValidator {
     browserHtml?: string,
     fetchRoute?: (path: string) => Promise<string>,
     liveIframeText?: string,
+    visitedRoutes?: Set<string>,
   ): Promise<ValidationResult[]> {
     if (!criteria || criteria.length === 0) return []
 
@@ -67,6 +68,16 @@ export class SuccessValidator {
                 }
               }
             }
+            break
+          }
+
+          case 'route_visited': {
+            // User must have actually navigated to this route inside the
+            // preview iframe. Used for "Click X to go to /Y" steps where
+            // a content-based check (browser_route_text) would always
+            // pass on load because fetchRoute returns the page content
+            // for any route — even routes the user never visited.
+            passed = !!criterion.route && !!visitedRoutes?.has(criterion.route)
             break
           }
 

--- a/docs/src/components/tutorial/TutorialWorkspace.tsx
+++ b/docs/src/components/tutorial/TutorialWorkspace.tsx
@@ -85,6 +85,7 @@ export const TutorialWorkspace: React.FC<TutorialWorkspaceProps> = ({ initialSlu
   }>({ isOpen: false, message: '' })
 
   const [resetConfirmModal, setResetConfirmModal] = useState(false)
+  const [resetStepConfirmModal, setResetStepConfirmModal] = useState(false)
 
   const [inputModal, setInputModal] = useState<{
     isOpen: boolean
@@ -95,16 +96,13 @@ export const TutorialWorkspace: React.FC<TutorialWorkspaceProps> = ({ initialSlu
 
   const [hierarchyOpen, setHierarchyOpen] = useState(false)
 
-  const handleResetClick = useCallback(
-    (e: React.MouseEvent) => {
-      if (e.metaKey || e.ctrlKey) {
-        setResetConfirmModal(true)
-      } else {
-        resetFiles()
-      }
-    },
-    [resetFiles],
-  )
+  const handleResetClick = useCallback((e: React.MouseEvent) => {
+    if (e.metaKey || e.ctrlKey) {
+      setResetConfirmModal(true)
+    } else {
+      setResetStepConfirmModal(true)
+    }
+  }, [])
 
   // Handle History (Browser Back/Forward)
   // ... (lines 50-70 unchanged)
@@ -121,10 +119,21 @@ export const TutorialWorkspace: React.FC<TutorialWorkspaceProps> = ({ initialSlu
   // here instead and never touch iframe.history.
   const [urlStack, setUrlStack] = useState<string[]>([currentStep.initialRoute || '/'])
   const [urlCursor, setUrlCursor] = useState(0)
+  // Track routes the user has actively visited inside the preview (link
+  // clicks, URL bar entries, back/forward). Excludes the step's
+  // initialRoute so "navigate to /X" criteria don't pass on load. Used
+  // by the route_visited success-criterion type.
+  const [visitedRoutes, setVisitedRoutes] = useState<Set<string>>(() => new Set())
 
   const handleNavigate = useCallback(
     (path: string) => {
       setCurrentUrl(path)
+      setVisitedRoutes((prev) => {
+        if (prev.has(path)) return prev
+        const next = new Set(prev)
+        next.add(path)
+        return next
+      })
       setUrlStack((prev) => {
         const truncated = prev.slice(0, urlCursor + 1)
         if (truncated[truncated.length - 1] === path) return truncated
@@ -142,6 +151,12 @@ export const TutorialWorkspace: React.FC<TutorialWorkspaceProps> = ({ initialSlu
     const next = urlCursor - 1
     setUrlCursor(next)
     setCurrentUrl(urlStack[next])
+    setVisitedRoutes((prev) => {
+      if (prev.has(urlStack[next])) return prev
+      const out = new Set(prev)
+      out.add(urlStack[next])
+      return out
+    })
     engineRef.current?.httpRequest('GET', urlStack[next])
   }, [urlCursor, urlStack])
 
@@ -150,6 +165,12 @@ export const TutorialWorkspace: React.FC<TutorialWorkspaceProps> = ({ initialSlu
     const next = urlCursor + 1
     setUrlCursor(next)
     setCurrentUrl(urlStack[next])
+    setVisitedRoutes((prev) => {
+      if (prev.has(urlStack[next])) return prev
+      const out = new Set(prev)
+      out.add(urlStack[next])
+      return out
+    })
     engineRef.current?.httpRequest('GET', urlStack[next])
   }, [urlCursor, urlStack])
 
@@ -321,6 +342,7 @@ export const TutorialWorkspace: React.FC<TutorialWorkspaceProps> = ({ initialSlu
     setCurrentUrl(initial)
     setUrlStack([initial])
     setUrlCursor(0)
+    setVisitedRoutes(new Set())
   }, [currentStep.slug, currentStep.initialRoute])
 
   // Unified Engine Sync Effect
@@ -415,6 +437,7 @@ export const TutorialWorkspace: React.FC<TutorialWorkspaceProps> = ({ initialSlu
         lastRenderedHtml,
         (path) => engineRef.current?.fetchRouteContent(path) || Promise.resolve(''),
         liveIframeText,
+        visitedRoutes,
       )
 
       if (!isMounted) return
@@ -437,7 +460,7 @@ export const TutorialWorkspace: React.FC<TutorialWorkspaceProps> = ({ initialSlu
     return () => {
       isMounted = false
     }
-  }, [files, lastRenderedHtml, liveIframeText, currentStep.successCriteria, isCompleted])
+  }, [files, lastRenderedHtml, liveIframeText, visitedRoutes, currentStep.successCriteria, isCompleted])
 
   // Reset completion on step change
   useEffect(() => {
@@ -503,6 +526,10 @@ export const TutorialWorkspace: React.FC<TutorialWorkspaceProps> = ({ initialSlu
             <span className="pw-breadcrumb-prefix">{currentStep.section}</span>
             {currentStep.section && <span className="pw-breadcrumb-separator">/</span>}
             <span className="pw-breadcrumb-title">{currentStep.title}</span>
+            <span className="pw-breadcrumb-separator ml-2">·</span>
+            <span className="pw-breadcrumb-prefix" title="Step progress">
+              {currentIndex + 1}/{allSteps.length}
+            </span>
           </div>
         </div>
 
@@ -618,6 +645,33 @@ export const TutorialWorkspace: React.FC<TutorialWorkspaceProps> = ({ initialSlu
         <div className="pw-modal-footer">
           <button className="pw-btn-primary" onClick={() => setModal({ ...modal, isOpen: false })}>
             OK
+          </button>
+        </div>
+      </Modal>
+
+      <Modal
+        isOpen={resetStepConfirmModal}
+        onClose={() => setResetStepConfirmModal(false)}
+        title="Reset This Step?"
+      >
+        <div className="pw-modal-body">
+          <p>
+            This will discard your edits and restore the starting code for this step. This action
+            cannot be undone.
+          </p>
+        </div>
+        <div className="pw-modal-footer">
+          <button className="pw-btn-secondary" onClick={() => setResetStepConfirmModal(false)}>
+            Cancel
+          </button>
+          <button
+            className="pw-btn-danger"
+            onClick={() => {
+              resetFiles()
+              setResetStepConfirmModal(false)
+            }}
+          >
+            Reset Step
           </button>
         </div>
       </Modal>

--- a/docs/src/components/tutorial/TutorialWorkspace.tsx
+++ b/docs/src/components/tutorial/TutorialWorkspace.tsx
@@ -460,7 +460,14 @@ export const TutorialWorkspace: React.FC<TutorialWorkspaceProps> = ({ initialSlu
     return () => {
       isMounted = false
     }
-  }, [files, lastRenderedHtml, liveIframeText, visitedRoutes, currentStep.successCriteria, isCompleted])
+  }, [
+    files,
+    lastRenderedHtml,
+    liveIframeText,
+    visitedRoutes,
+    currentStep.successCriteria,
+    isCompleted,
+  ])
 
   // Reset completion on step change
   useEffect(() => {

--- a/docs/src/components/tutorial/types.ts
+++ b/docs/src/components/tutorial/types.ts
@@ -19,7 +19,13 @@ export interface AllowedBehavior {
 }
 
 export interface SuccessCriteria {
-  type: 'file_exists' | 'file_contains' | 'browser_route_text' | 'browser_element' | 'custom'
+  type:
+    | 'file_exists'
+    | 'file_contains'
+    | 'browser_route_text'
+    | 'browser_element'
+    | 'route_visited'
+    | 'custom'
   target?: string // File path or CSS selector
   pattern?: string // Content to match
   route?: string // For browser_route_text

--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -37,6 +37,7 @@ export const collections = {
                 'file_contains',
                 'browser_route_text',
                 'browser_element',
+                'route_visited',
                 'custom',
               ]),
               target: z.string().optional(),

--- a/docs/src/content/docs/tutorial/03-events/03-modifiers.mdx
+++ b/docs/src/content/docs/tutorial/03-events/03-modifiers.mdx
@@ -53,7 +53,7 @@ successCriteria:
   - type: browser_route_text
     route: '/'
     description: "Click the 'Once' button to see the success message"
-    pattern: '✓ Triggered once!'
+    pattern: 'Triggered'
 pagesDir: pages
 ---
 

--- a/docs/src/content/docs/tutorial/08-routing/01-explicit.mdx
+++ b/docs/src/content/docs/tutorial/08-routing/01-explicit.mdx
@@ -22,14 +22,12 @@ files:
         <a href="/">Go Home</a>
       </div>
 successCriteria:
-  - type: browser_route_text
-    description: "Click 'Go to About' and verify you are on the About page"
+  - type: route_visited
+    description: "Click 'Go to About' to navigate to /about"
     route: '/about'
-    pattern: 'About Page'
-  - type: browser_route_text
-    description: "Click 'Go Home' and verify you are back on the Home page"
+  - type: route_visited
+    description: "Click 'Go Home' to return to /"
     route: '/'
-    pattern: 'Home Page'
 pagesDir: pages
 ---
 

--- a/docs/src/content/docs/tutorial/08-routing/02-path-dict.mdx
+++ b/docs/src/content/docs/tutorial/08-routing/02-path-dict.mdx
@@ -49,10 +49,9 @@ successCriteria:
     description: 'Wrap settings in {$if path.settings}'
     target: pages/main.wire
     pattern: '{$if path.settings}'
-  - type: browser_route_text
+  - type: route_visited
     route: '/menu/settings'
-    description: 'Navigate to /menu/settings and see the settings list'
-    pattern: 'Preferences'
+    description: "Click 'Go to Settings' to navigate to /menu/settings"
 pagesDir: pages
 initialRoute: '/menu'
 ---

--- a/uv.lock
+++ b/uv.lock
@@ -547,7 +547,7 @@ toml = [
 
 [[package]]
 name = "create-pywire-app"
-version = "0.10.0"
+version = "0.11.0"
 source = { editable = "packages/create-pywire-app" }
 dependencies = [
     { name = "jinja2" },
@@ -1857,7 +1857,7 @@ wheels = [
 
 [[package]]
 name = "pywire"
-version = "0.13.0"
+version = "0.14.2"
 source = { editable = "packages/pywire" }
 dependencies = [
     { name = "msgpack" },
@@ -1870,6 +1870,7 @@ build = [
     { name = "pywire-parser" },
 ]
 cli = [
+    { name = "jinja2" },
     { name = "pywire-cli" },
 ]
 dev = [
@@ -1877,6 +1878,7 @@ dev = [
     { name = "build" },
     { name = "coverage" },
     { name = "httpx" },
+    { name = "jinja2" },
     { name = "msgpack-types" },
     { name = "nox" },
     { name = "pydantic" },
@@ -1912,6 +1914,7 @@ requires-dist = [
     { name = "coverage", marker = "extra == 'dev'", specifier = ">=7.3.0" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.23.0" },
     { name = "hypercorn", marker = "extra == 'http3'", specifier = ">=0.14.0" },
+    { name = "jinja2", marker = "extra == 'cli'", specifier = ">=3.1.0" },
     { name = "msgpack", specifier = ">=1.0.0" },
     { name = "msgpack-types", marker = "extra == 'dev'" },
     { name = "nox", marker = "extra == 'dev'" },
@@ -1936,7 +1939,7 @@ dev = [{ name = "mypy", specifier = ">=1.19.1" }]
 
 [[package]]
 name = "pywire-auth"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "packages/pywire-auth" }
 dependencies = [
     { name = "argon2-cffi" },
@@ -1978,7 +1981,7 @@ provides-extras = ["google", "github", "microsoft", "facebook", "apple", "auth0"
 
 [[package]]
 name = "pywire-cli"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "packages/pywire-cli" }
 dependencies = [
     { name = "jinja2" },
@@ -2018,7 +2021,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "pywire-language-server"
-version = "0.6.2"
+version = "0.7.0"
 source = { editable = "packages/pywire-language-server" }
 dependencies = [
     { name = "pygls" },
@@ -2075,7 +2078,7 @@ requires-dist = [
 
 [[package]]
 name = "pywire-parser"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "packages/pywire-parser" }
 dependencies = [
     { name = "tree-sitter" },


### PR DESCRIPTION
## Summary

Tutorial round-2 walkthrough surfaced five smaller issues. Fixing them together since they're all in the same files.

- **Step 13 (`@click.once`)**: behavioral checker required the verbatim string `"✓ Triggered once!"` (with checkmark glyph). Loosened to `"Triggered"` so users who omit the glyph still pass.

- **Step 27 (explicit routing)**: both criteria (`browser_route_text` for `/about` and `/`) passed on load because `fetchRoute` returns content for any route — even routes the user never visited. Added a new `route_visited` criterion type that tracks which routes the user actually navigated to inside the preview iframe (link clicks, URL bar entries, back/forward). Resets to empty on step change.

- **Step 28 (path dict)**: same conversion for the "click 'Go to Settings'" criterion. The intent of "click X to navigate to Y" is genuinely behavioral, not content-based.

- **Reset button (↺)**: regular click now opens a step-scoped confirm modal (was: wipes files immediately, no confirmation). Cmd/Ctrl-click still opens the existing reset-ALL modal.

- **Step progress counter**: breadcrumb now shows `N/M` so users can see how far through the tutorial they are.

The unaddressed item from the report — step 25 `!path` nav task not firing on live edit — should resolve once #223 deploys: that PR adds `ws_handler.broadcast_reload()` to `sync_pages`, which makes the iframe re-render via WS update, refreshing `liveIframeText` so the validator picks up the new content without a full page reload.

## Test plan

- [ ] Step 13: type the `@click.once` solution without the `✓ ` prefix in the success message; click button; task 2 checks
- [ ] Step 27: open step — both nav tasks should be unchecked; click "Go to About" → task 1 checks; click "Go Home" → task 2 checks
- [ ] Step 27: navigate away and back to step 27 — tasks reset to unchecked
- [ ] Step 28: open step — task 3 unchecked; click "Go to Settings" → task 3 checks
- [ ] Reset (↺): regular click prompts for confirmation; Cancel keeps edits; Reset Step restores starting code; Cmd/Ctrl-click still opens reset-ALL modal
- [ ] Breadcrumb shows `N/M` and updates on step change