### PR TITLE
fix(pywire-docs): landing counter uses shorthand count += 1

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -39,7 +39,7 @@ Define a component in `counter.wire`:
 count = wire(0)
 ---
 <p>Count: {count}</p>
-<button @click={count.value += 1}>
+<button @click={count += 1}>
     Add One
 </button>`}
   lang="pywire"


### PR DESCRIPTION
Landing snippet was `count.value += 1` — the marketing pitch is the shorthand. One-line fix.