### PR TITLE
fix: error-system overhaul (line numbers, design system, SPA leak)

### DIFF
--- a/packages/pywire-language-server/pyproject.toml
+++ b/packages/pywire-language-server/pyproject.toml
@@ -13,7 +13,7 @@ requires-python = ">=3.11"
 dependencies = [
     "pygls>=1.3.0",
     "ty>=0.0.15",
-    "pywire-parser>=0.6.0",
+    "pywire-parser>=0.8.0",
 ]
 
 [project.scripts]

--- a/packages/pywire-language-server/src/pywire_language_server/_compat.py
+++ b/packages/pywire-language-server/src/pywire_language_server/_compat.py
@@ -7,7 +7,7 @@ CLAUDE.md "Version Floors" for the bump protocol.
 from importlib.metadata import PackageNotFoundError, version
 
 _FLOORS = {
-    "pywire-parser": "0.6.0",
+    "pywire-parser": "0.8.0",
 }
 
 

--- a/packages/pywire-parser/pyproject.toml
+++ b/packages/pywire-parser/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pywire-parser"
-version = "0.7.0"
+version = "0.8.0"
 description = "Pure-Python parser for PyWire .wire files using tree-sitter"
 authors = [
     { name = "Reece Holmdahl", email = "reece@pywire.dev" },

--- a/packages/pywire-parser/src/pywire_parser/ast_nodes.py
+++ b/packages/pywire-parser/src/pywire_parser/ast_nodes.py
@@ -386,6 +386,10 @@ class ParsedPyWire:
     python_code: str = ""  # Raw Python section (between --- fences)
     python_ast: Optional[ast.Module] = None  # Parsed Python AST
     file_path: str = ""
+    # 1-based .wire-file line where python_code begins (0 if no python section).
+    # Set on the python_ast via ast.increment_lineno so traceback lines align
+    # with the .wire source.
+    python_start_line: int = 0
 
     def get_directive_by_type(self, directive_type: type) -> Optional[Directive]:
         """Get first directive of specified type."""

--- a/packages/pywire-parser/src/pywire_parser/parser.py
+++ b/packages/pywire-parser/src/pywire_parser/parser.py
@@ -165,6 +165,11 @@ class PyWireParser:
         self._validate_snippet_scopes(template_nodes, file_path)
 
         python_section = doc.python_code
+        python_start_line = doc.python_start_line
+        # Offset from python-section line numbers to .wire-file line numbers.
+        # python_start_line is the .wire line of the FIRST python line, so a
+        # python lineno of 1 maps to that line; offset = python_start_line - 1.
+        line_offset = max(python_start_line - 1, 0)
         python_ast = None
 
         if python_section.strip():
@@ -177,8 +182,14 @@ class PyWireParser:
                 raise PyWireSyntaxError(
                     f"Python syntax error: {e.msg}",
                     file_path=file_path,
-                    line=e.lineno or 1,
+                    line=(e.lineno or 1) + line_offset,
                 )
+
+            # Shift python AST line numbers into .wire-file coordinates so
+            # compile()'d bytecode and runtime tracebacks point at the right
+            # line in the .wire source.
+            if line_offset:
+                ast.increment_lineno(python_ast, line_offset)
 
         return ParsedPyWire(
             directives=directives,
@@ -186,6 +197,7 @@ class PyWireParser:
             python_code=python_section,
             python_ast=python_ast,
             file_path=file_path,
+            python_start_line=python_start_line,
         )
 
     def _map_rust_directive(self, d: Any, file_path: str) -> Any:

--- a/packages/pywire-parser/src/pywire_parser/ts_parser.py
+++ b/packages/pywire-parser/src/pywire_parser/ts_parser.py
@@ -80,6 +80,9 @@ class ParsedDocument:
     directives: List[ParsedDirective]
     python_code: str
     template: List[ParsedNode]
+    # 1-based line number in the .wire file where the python_code section begins.
+    # 0 if no python frontmatter is present.
+    python_start_line: int = 0
 
 
 def _get_text(source: bytes, node: Node) -> str:
@@ -278,6 +281,7 @@ def parse(source: str) -> ParsedDocument:
 
     directives: List[ParsedDirective] = []
     python_code = ""
+    python_start_line = 0
     template: List[ParsedNode] = []
 
     cursor = root.walk()
@@ -298,6 +302,8 @@ def parse(source: str) -> ParsedDocument:
                 content_node = child.child_by_field_name("python_content")
                 if content_node:
                     python_code += _get_text(source_bytes, content_node)
+                    if python_start_line == 0:
+                        python_start_line = content_node.start_point[0] + 1
                 else:
                     # Fallback: check children for python_content node
                     fm_cursor = child.walk()
@@ -305,6 +311,10 @@ def parse(source: str) -> ParsedDocument:
                         while True:
                             if fm_cursor.node.type == "python_content":
                                 python_code += _get_text(source_bytes, fm_cursor.node)
+                                if python_start_line == 0:
+                                    python_start_line = (
+                                        fm_cursor.node.start_point[0] + 1
+                                    )
                             if not fm_cursor.goto_next_sibling():
                                 break
 
@@ -325,6 +335,7 @@ def parse(source: str) -> ParsedDocument:
         directives=directives,
         python_code=python_code,
         template=template,
+        python_start_line=python_start_line,
     )
 
 

--- a/packages/pywire/pyproject.toml
+++ b/packages/pywire/pyproject.toml
@@ -38,7 +38,7 @@ forms = [
 # that ship pre-compiled artifacts (e.g. Cloudflare Workers via Pyodide
 # where AOT-compiled wheels aren't available) can omit this extra.
 build = [
-    "pywire-parser>=0.6.0",
+    "pywire-parser>=0.8.0",
 ]
 # jinja2 backs the dev-mode compile-error page renderer (error_renderer.py);
 # `pywire run` with debug=False never imports it. It belongs on the dev/cli

--- a/packages/pywire/src/pywire/_compat.py
+++ b/packages/pywire/src/pywire/_compat.py
@@ -18,7 +18,7 @@ from importlib.metadata import PackageNotFoundError, version
 _FLOORS = {
     # pywire-parser is a [build] extra. When installed, must match the
     # AST/directive surface this pywire release was built against.
-    "pywire-parser": "0.6.0",
+    "pywire-parser": "0.8.0",
 }
 
 

--- a/packages/pywire/src/pywire/client/src/core/app.test.ts
+++ b/packages/pywire/src/pywire/client/src/core/app.test.ts
@@ -8,6 +8,8 @@ vi.mock('./transport-manager', () => {
       return {
         onMessage: vi.fn(),
         onStatusChange: vi.fn(),
+        onGiveUp: vi.fn(),
+        setMaxReconnectAttempts: vi.fn(),
         connect: vi.fn(),
         send: vi.fn(),
         getActiveTransport: vi.fn().mockReturnValue('mock'),

--- a/packages/pywire/src/pywire/client/src/core/app.ts
+++ b/packages/pywire/src/pywire/client/src/core/app.ts
@@ -89,7 +89,6 @@ export class PyWireApp {
     this.updater = new DOMUpdater(this.config.debug)
     this.eventHandler = new UnifiedEventHandler(this)
     this.reconnectOverlay = new ReconnectOverlay({
-      maxAttempts: this.config.reconnectMaxAttempts,
       enabled: this.config.reconnectOverlay,
     })
     this.refManager = new RefManager(
@@ -153,6 +152,16 @@ export class PyWireApp {
       // Interactive mode: connect transport for real-time updates
       this.transport.onMessage((msg) => this.handleMessage(msg))
       this.transport.onStatusChange((connected) => this.handleStatusChange(connected))
+      this.transport.onGiveUp(() => {
+        // Transport has exhausted its reconnect budget — flip the overlay
+        // into its "failed" state so the user is offered a Reload action
+        // (built-in template) or whatever the custom __reconnect__.wire
+        // template renders for `[data-pw-reconnect-state="failed"]`.
+        this.reconnectOverlay.markFailed()
+      })
+      if (this.config.reconnectMaxAttempts !== undefined) {
+        this.transport.setMaxReconnectAttempts(this.config.reconnectMaxAttempts)
+      }
 
       this.connectStartTime = performance.now()
       try {
@@ -256,13 +265,9 @@ export class PyWireApp {
         // Apply reconnect config from server metadata
         if (meta.reconnect_max_attempts !== undefined) {
           this.config.reconnectMaxAttempts = meta.reconnect_max_attempts
+        }
+        if (meta.reconnect_overlay !== undefined) {
           this.reconnectOverlay = new ReconnectOverlay({
-            maxAttempts: meta.reconnect_max_attempts,
-            enabled: meta.reconnect_overlay ?? this.config.reconnectOverlay,
-          })
-        } else if (meta.reconnect_overlay !== undefined) {
-          this.reconnectOverlay = new ReconnectOverlay({
-            maxAttempts: this.config.reconnectMaxAttempts,
             enabled: meta.reconnect_overlay,
           })
         }

--- a/packages/pywire/src/pywire/client/src/core/app.ts
+++ b/packages/pywire/src/pywire/client/src/core/app.ts
@@ -474,6 +474,16 @@ export class PyWireApp {
         credentials: 'same-origin',
       })
 
+      // Error responses (4xx/5xx) carry the server's error page HTML — a
+      // *different* document than the source page. Morphing it into the
+      // current DOM would leak the error template's <style> and tokens
+      // into the host app. Fall back to a full browser navigation so the
+      // error page renders cleanly with its own <head>.
+      if (!response.ok) {
+        window.location.href = path
+        return
+      }
+
       if (response.redirected) {
         // Follow redirect — update URL and re-navigate
         const redirectPath = new URL(response.url).pathname
@@ -528,6 +538,14 @@ export class PyWireApp {
         credentials: 'same-origin',
         redirect: 'follow',
       })
+
+      // 4xx/5xx responses carry the error page — a different document.
+      // Morphing it into the current DOM would leak its styles into the
+      // host app. Fall back to a full navigation.
+      if (!response.ok) {
+        window.location.href = path
+        return
+      }
 
       if (response.redirected) {
         const redirectPath = new URL(response.url).pathname

--- a/packages/pywire/src/pywire/client/src/core/reconnect-overlay.ts
+++ b/packages/pywire/src/pywire/client/src/core/reconnect-overlay.ts
@@ -12,42 +12,46 @@ import { logger } from './logger'
  * so templates can style both states with CSS alone.
  *
  * Reconnection is driven by the transport layer (e.g. WebSocket auto-reconnect).
- * This overlay tracks elapsed attempts on an exponential-backoff schedule and
- * transitions to "failed" after `maxAttempts` intervals have elapsed without
- * the connection being restored.
+ * The transport calls `markFailed()` when it has exhausted its reconnect budget
+ * — this overlay does NOT independently track attempts, so the visual state
+ * stays in lockstep with whether the transport is still trying.
  */
 export class ReconnectOverlay {
   private element: HTMLElement | null = null
-  private maxAttempts: number
   private enabled: boolean
-  private attemptCount = 0
-  private failTimer: ReturnType<typeof setTimeout> | null = null
 
-  constructor(opts: { maxAttempts?: number; enabled?: boolean } = {}) {
-    this.maxAttempts = opts.maxAttempts ?? 10
+  constructor(opts: { enabled?: boolean } = {}) {
     this.enabled = opts.enabled ?? true
   }
 
   /**
-   * Show the overlay and begin tracking reconnection attempts.
-   * The transport layer handles actual reconnection; this overlay
-   * provides visual feedback and gives up after maxAttempts.
+   * Show the overlay in its "reconnecting" state. Idempotent.
    */
   show(): void {
     if (!this.enabled) return
-    this.attemptCount = 0
     this.ensureElement()
     if (!this.element) return
     this.element.style.display = ''
     this.setState('reconnecting')
-    this.scheduleFailCheck()
   }
 
   /**
-   * Hide the overlay and cancel any pending fail timer.
+   * Switch the overlay into its "failed" state. Templates style this with
+   * `[data-pw-reconnect-state="failed"]` (e.g. swap the spinner for a
+   * Reload button). Called by the transport once it gives up.
+   */
+  markFailed(): void {
+    if (!this.enabled) return
+    this.ensureElement()
+    if (!this.element) return
+    this.element.style.display = ''
+    this.setState('failed')
+  }
+
+  /**
+   * Hide the overlay.
    */
   hide(): void {
-    this.cancelTimer()
     if (this.element) {
       this.element.style.display = 'none'
     }
@@ -57,7 +61,6 @@ export class ReconnectOverlay {
    * Clean up the overlay element completely.
    */
   destroy(): void {
-    this.cancelTimer()
     if (this.element) {
       this.element.remove()
       this.element = null
@@ -71,37 +74,6 @@ export class ReconnectOverlay {
   private setState(state: 'reconnecting' | 'failed'): void {
     if (!this.element) return
     this.element.setAttribute('data-pw-reconnect-state', state)
-  }
-
-  private cancelTimer(): void {
-    if (this.failTimer !== null) {
-      clearTimeout(this.failTimer)
-      this.failTimer = null
-    }
-  }
-
-  /**
-   * Schedule the next "attempt" tick. Each tick increments the counter and,
-   * if we've hit maxAttempts without the connection being restored, sets
-   * the overlay state to "failed".
-   */
-  private scheduleFailCheck(): void {
-    if (this.attemptCount >= this.maxAttempts) {
-      this.setState('failed')
-      logger.warn(`PyWire: Reconnection failed after ${this.maxAttempts} attempts`)
-      return
-    }
-
-    // Exponential backoff: 1s, 2s, 4s, 8s, ..., capped at 30s
-    const delay = Math.min(1000 * Math.pow(2, this.attemptCount), 30000)
-    logger.log(
-      `PyWire: Waiting for reconnection (attempt ${this.attemptCount + 1}/${this.maxAttempts}, next check in ${delay}ms)`
-    )
-
-    this.failTimer = setTimeout(() => {
-      this.attemptCount++
-      this.scheduleFailCheck()
-    }, delay)
   }
 
   /**

--- a/packages/pywire/src/pywire/client/src/core/transport-manager.ts
+++ b/packages/pywire/src/pywire/client/src/core/transport-manager.ts
@@ -34,6 +34,8 @@ export class TransportManager {
   private config: TransportConfig
   private messageHandlers: ((msg: ServerMessage) => void)[] = []
   private statusHandlers: ((connected: boolean) => void)[] = []
+  private giveUpHandlers: (() => void)[] = []
+  private maxReconnectAttempts: number | null = null
 
   constructor(config: Partial<TransportConfig> = {}) {
     this.config = { ...DEFAULT_CONFIG, ...config }
@@ -59,6 +61,15 @@ export class TransportManager {
         this.transport.onStatusChange((connected) => {
           this.notifyStatusHandlers(connected)
         })
+
+        // Forward give-up notifications + max-attempts config to the
+        // active transport (only if it supports reconnection).
+        if (this.maxReconnectAttempts !== null && this.transport.setMaxReconnectAttempts) {
+          this.transport.setMaxReconnectAttempts(this.maxReconnectAttempts)
+        }
+        if (this.transport.onGiveUp) {
+          this.transport.onGiveUp(() => this.notifyGiveUpHandlers())
+        }
 
         await this.transport.connect()
         logger.log(`PyWire: Connected via ${this.transport.name}`)
@@ -127,9 +138,37 @@ export class TransportManager {
     this.statusHandlers.push(handler)
   }
 
+  /**
+   * Register a handler invoked when the active transport has exhausted
+   * its reconnect budget. Surfaces a single notification per session.
+   */
+  onGiveUp(handler: () => void): void {
+    this.giveUpHandlers.push(handler)
+  }
+
+  /**
+   * Set the reconnect-attempts cap forwarded to any reconnecting transport.
+   */
+  setMaxReconnectAttempts(n: number): void {
+    this.maxReconnectAttempts = n
+    if (this.transport?.setMaxReconnectAttempts) {
+      this.transport.setMaxReconnectAttempts(n)
+    }
+  }
+
   private notifyStatusHandlers(connected: boolean): void {
     for (const handler of this.statusHandlers) {
       handler(connected)
+    }
+  }
+
+  private notifyGiveUpHandlers(): void {
+    for (const handler of this.giveUpHandlers) {
+      try {
+        handler()
+      } catch (e) {
+        logger.error('PyWire: Error in giveUp handler', e)
+      }
     }
   }
 

--- a/packages/pywire/src/pywire/client/src/core/transports/base.ts
+++ b/packages/pywire/src/pywire/client/src/core/transports/base.ts
@@ -26,6 +26,19 @@ export interface Transport {
   /** Force an immediate reconnect attempt (e.g. triggered by window.online). No-op if already connected. */
   forceReconnect?(): void
 
+  /**
+   * Register a handler invoked when the transport has exhausted its
+   * reconnect budget and is giving up. Receives no arguments. Implementations
+   * that don't reconnect (e.g. HTTP polling) may never invoke this.
+   */
+  onGiveUp?(handler: () => void): void
+
+  /**
+   * Set the maximum number of reconnect attempts before the transport
+   * gives up. Implementations that don't reconnect may ignore this.
+   */
+  setMaxReconnectAttempts?(n: number): void
+
   /** Transport name for debugging */
   readonly name: string
 }

--- a/packages/pywire/src/pywire/client/src/core/transports/websocket.ts
+++ b/packages/pywire/src/pywire/client/src/core/transports/websocket.ts
@@ -13,14 +13,17 @@ export class WebSocketTransport extends BaseTransport {
 
   private socket: WebSocket | null = null
   private reconnectAttempts = 0
-  private maxReconnectDelay = 5000
+  private maxReconnectAttempts = 10
+  private maxReconnectDelay = 30000
   private shouldReconnect = true
+  private gaveUp = false
   private readonly baseUrl: string
   private sessionId: string | null = null
   private lastMessageTime = 0
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null
   private readonly heartbeatCheckMs = 5000
   private readonly deadConnectionMs = 40000
+  private giveUpHandlers: (() => void)[] = []
 
   constructor(url?: string) {
     super()
@@ -44,6 +47,14 @@ export class WebSocketTransport extends BaseTransport {
     this.sessionId = sessionId
   }
 
+  setMaxReconnectAttempts(n: number): void {
+    this.maxReconnectAttempts = n
+  }
+
+  onGiveUp(handler: () => void): void {
+    this.giveUpHandlers.push(handler)
+  }
+
   connect(): Promise<void> {
     return new Promise((resolve, reject) => {
       try {
@@ -58,6 +69,7 @@ export class WebSocketTransport extends BaseTransport {
           this.startHeartbeat()
           this.notifyStatus(true)
           this.reconnectAttempts = 0
+          this.gaveUp = false
           resolve()
         }
 
@@ -85,9 +97,16 @@ export class WebSocketTransport extends BaseTransport {
           }
         }
 
-        this.socket.onerror = (error) => {
-          logger.error('PyWire: WebSocket error', error)
-          if (!this.connected) {
+        this.socket.onerror = () => {
+          // WebSocket "error" events fire on every failed connect
+          // attempt during reconnect backoff. Suppress them in that
+          // path — the browser still prints its own native
+          // "WebSocket connection to ... failed" line, and we'll log
+          // a single warn() once we give up. Surface a real error
+          // only on the *initial* connect (no successful open yet
+          // and not mid-reconnect).
+          if (!this.connected && this.reconnectAttempts === 0) {
+            logger.warn('PyWire: WebSocket failed to connect')
             reject(new Error('WebSocket connection failed'))
           }
         }
@@ -118,9 +137,14 @@ export class WebSocketTransport extends BaseTransport {
   forceReconnect(): void {
     if (this.socket && this.socket.readyState === WebSocket.OPEN) {
       this.socket.close()
-    } else if (this.shouldReconnect) {
-      this.scheduleReconnect()
+      return
     }
+    // Reset reconnect budget on a manual force (network came back online,
+    // user-initiated retry) so we resume attempts even after giving up.
+    this.gaveUp = false
+    this.shouldReconnect = true
+    this.reconnectAttempts = 0
+    this.scheduleReconnect()
   }
 
   private startHeartbeat(): void {
@@ -141,11 +165,30 @@ export class WebSocketTransport extends BaseTransport {
   }
 
   private scheduleReconnect(): void {
-    const delay = Math.min(1000 * Math.pow(2, this.reconnectAttempts), this.maxReconnectDelay)
+    if (this.reconnectAttempts >= this.maxReconnectAttempts) {
+      if (this.gaveUp) return
+      this.gaveUp = true
+      this.shouldReconnect = false
+      logger.warn(
+        `PyWire: Reconnection failed after ${this.maxReconnectAttempts} attempts; giving up`
+      )
+      for (const handler of this.giveUpHandlers) {
+        try {
+          handler()
+        } catch (e) {
+          logger.error('PyWire: Error in giveUp handler', e)
+        }
+      }
+      return
+    }
 
-    if (DEBUG_CONNECTION) logger.log(`PyWire: Reconnecting in ${delay}ms...`)
+    const delay = Math.min(1000 * Math.pow(2, this.reconnectAttempts), this.maxReconnectDelay)
+    logger.log(
+      `PyWire: Reconnecting in ${delay}ms (attempt ${this.reconnectAttempts + 1}/${this.maxReconnectAttempts})`
+    )
 
     setTimeout(() => {
+      if (!this.shouldReconnect) return
       this.reconnectAttempts++
       this.connect().catch(() => {
         // Reconnect will be scheduled again on close

--- a/packages/pywire/src/pywire/runtime/app.py
+++ b/packages/pywire/src/pywire/runtime/app.py
@@ -1196,6 +1196,15 @@ class PyWire:
                     class ModeAwareErrorPage(BasePage):
                         """Error page that decides whether to show details or trigger 500."""
 
+                        # Marker checked by `WebSocketHandler.broadcast_reload`
+                        # so that hot-reload after a fix forces a hard browser
+                        # reload instead of morphing the recovered page HTML
+                        # into the still-displayed error DOM (which would
+                        # leak the error template's <head>/<style> into the
+                        # host app — Pico stylesheets gone, engineering grid
+                        # stuck on body, etc.).
+                        __is_compile_error_page__ = True
+
                         def __init__(
                             self, request: Request, *args: Any, **kwargs: Any
                         ) -> None:

--- a/packages/pywire/src/pywire/runtime/compile_error_page.py
+++ b/packages/pywire/src/pywire/runtime/compile_error_page.py
@@ -123,9 +123,7 @@ class CompileErrorPage(BasePage):
     async def render(self, init: bool = True) -> HTMLResponse:
         is_syntax = isinstance(self.error, PyWireSyntaxError)
         title = "PyWire Syntax Error" if is_syntax else "Compilation Error"
-        tagline = random.choice(
-            _TAGLINES_SYNTAX if is_syntax else _TAGLINES_RUNTIME
-        )
+        tagline = random.choice(_TAGLINES_SYNTAX if is_syntax else _TAGLINES_RUNTIME)
         root_path = ""
         try:
             root_path = str(self.request.scope.get("root_path", "") or "")

--- a/packages/pywire/src/pywire/runtime/compile_error_page.py
+++ b/packages/pywire/src/pywire/runtime/compile_error_page.py
@@ -1,5 +1,6 @@
 import linecache
 import os
+import random
 import traceback
 from typing import Any, Optional, Union
 
@@ -9,6 +10,29 @@ from starlette.responses import HTMLResponse
 from pywire import __version__
 from pywire.compiler.exceptions import PyWireSyntaxError
 from pywire.runtime.page import BasePage
+
+# Tagline pools — random electricity/wire puns per error category.
+# Keep short, technical, never cute. Sentence case, period.
+_TAGLINES_SYNTAX = [
+    "Solder cracked.",
+    "Bad joint in the wire.",
+    "Polarity reversed.",
+    "Pin out of place.",
+    "Wires crossed.",
+    "Compiler smelled smoke.",
+    "Lead came loose.",
+    "Open trace on the board.",
+]
+_TAGLINES_RUNTIME = [
+    "The wire shorted.",
+    "Sparks flew.",
+    "Magic smoke escaped.",
+    "Fuse blew.",
+    "Circuit overloaded.",
+    "Ground fault detected.",
+    "Insulation failed.",
+    "Capacitor sang its last.",
+]
 
 
 class CompileErrorPage(BasePage):
@@ -97,10 +121,10 @@ class CompileErrorPage(BasePage):
         return self.error_file
 
     async def render(self, init: bool = True) -> HTMLResponse:
-        title = (
-            "PyWire Syntax Error"
-            if isinstance(self.error, PyWireSyntaxError)
-            else "Compilation Error"
+        is_syntax = isinstance(self.error, PyWireSyntaxError)
+        title = "PyWire Syntax Error" if is_syntax else "Compilation Error"
+        tagline = random.choice(
+            _TAGLINES_SYNTAX if is_syntax else _TAGLINES_RUNTIME
         )
         root_path = ""
         try:
@@ -115,6 +139,7 @@ class CompileErrorPage(BasePage):
             "error/compile_error.html.j2",
             {
                 "title": title,
+                "tagline": tagline,
                 "file_display": self._display_path(),
                 "error_line": self.error_line,
                 "error_message": self.error_message,

--- a/packages/pywire/src/pywire/runtime/websocket.py
+++ b/packages/pywire/src/pywire/runtime/websocket.py
@@ -44,6 +44,14 @@ class WebSocketHandler:
         # observe or mutate them from ``document.cookie``. All other keys
         # are reconciled against ``document.cookie`` on each SPA relocate.
         self._connection_httponly: Dict[WebSocket, Set[str]] = {}
+        # Per-connection flag set when the last response sent to the
+        # browser was an error page (4xx/5xx) or the connection failed
+        # to resolve a route. While this is set, hot-reload (broadcast
+        # _reload) skips the state-preserving morph path and forces a
+        # hard browser reload — morphing the fixed page into the error
+        # DOM leaks the error template's <style> + tokens into the
+        # host app. Cleared on a successful page render.
+        self._connection_in_error: Set[WebSocket] = set()
         # Per-connection live-auth subscription task — fan-out from the
         # app's AuthChannel pushes update/revoke events into the WS so the
         # page re-renders when the current user's claims change or the
@@ -227,6 +235,7 @@ class WebSocketHandler:
 
         self.active_connections.discard(websocket)
         self.connection_pages.pop(websocket, None)
+        self._connection_in_error.discard(websocket)
         # Keep session in store (TTL handles cleanup) — enables reconnect
         self.session_ids.pop(websocket, None)
         self._connection_cookies.pop(websocket, None)
@@ -410,10 +419,17 @@ class WebSocketHandler:
             )
             if not result:
                 print(f"Init: No route found for path: {path}")
+                # Browser likely arrived from a full nav and is currently
+                # showing the built-in error page. Mark the connection so
+                # the next hot-reload forces a hard browser reload rather
+                # than morphing fixed-page HTML into the error DOM.
+                self._connection_in_error.add(websocket)
                 await websocket.send_bytes(
                     msgpack.packb({"type": "error", "error": "Not Found"})
                 )
                 return
+            # Resolved a real page — clear any prior error flag.
+            self._connection_in_error.discard(websocket)
 
             page, _params, _variant_name = result
 
@@ -658,13 +674,28 @@ class WebSocketHandler:
                 return
 
             if response.status >= 400:
-                # Error response — send the error page HTML
-                html = response.body.decode("utf-8")
-                payload: Dict[str, Any] = {"type": "update", "html": html}
+                # Error response — the body is the server's error page, a
+                # *different* document than the current SPA page. Morphing
+                # it into the live DOM would leak the error template's
+                # <style> and tokens into the host app (and dangle the
+                # auth-demo's stylesheets after recovery). Instead, sync
+                # any cookies and tell the client to do a full reload —
+                # the URL bar already points at the requested path (set
+                # by `history.pushState` before the relocate fired), so
+                # the browser will fetch and render the error page fresh
+                # with its own <head>.
+                self._connection_in_error.add(websocket)
+                payload: Dict[str, Any] = {"type": "reload"}
                 if cookie_commands:
-                    payload["commands"] = cookie_commands
+                    # Apply any Set-Cookie commands before reload so the
+                    # subsequent full-page request sees the updated jar.
+                    await self._send_update_payload(
+                        websocket, {"regions": [], "commands": cookie_commands}
+                    )
                 await websocket.send_bytes(msgpack.packb(payload))
                 return
+            # Successful relocate — clear any prior error flag.
+            self._connection_in_error.discard(websocket)
 
             # 5. Success (200) — send body HTML and set up local page instance.
             # Resolve the new page first so we can both attach meta to the
@@ -746,6 +777,7 @@ class WebSocketHandler:
             # If relocation fails, force a full reload so the browser
             # hits the server and gets the proper error page
             print(f"Error handling relocate: {e}", file=sys.stderr)
+            self._connection_in_error.add(websocket)
             await websocket.send_bytes(msgpack.packb({"type": "reload"}))
         finally:
             log_callback_ctx.reset(token)
@@ -1004,8 +1036,34 @@ class WebSocketHandler:
         disconnected = set()
         for connection in list(self.active_connections):
             try:
+                # If the browser is currently showing the built-in error
+                # page (a 4xx/5xx came back during init or relocate, or
+                # the connection's last response was an ErrorBasePage),
+                # the live DOM is the error template. Morphing fixed-
+                # page HTML into it leaks the error template's <style>
+                # + tokens into the host app. Force a hard reload so
+                # the browser fetches a clean document for the URL it's
+                # already showing.
+                if connection in self._connection_in_error:
+                    await connection.send_bytes(
+                        msgpack.packb({"type": "reload"})
+                    )
+                    self._connection_in_error.discard(connection)
+                    continue
+
                 old_page = self.connection_pages.get(connection)
                 if old_page:
+                    from pywire.runtime.page import ErrorBasePage
+
+                    is_error_page = isinstance(old_page, ErrorBasePage) or getattr(
+                        type(old_page), "__is_compile_error_page__", False
+                    )
+                    if is_error_page:
+                        await connection.send_bytes(
+                            msgpack.packb({"type": "reload"})
+                        )
+                        continue
+
                     try:
                         # Get the current URL path from the old page's request
                         path = old_page.request.url.path
@@ -1129,6 +1187,17 @@ class WebSocketHandler:
                             e,
                             exc_info=True,
                         )
+                        # Mark the connection so the *next* hot-reload also
+                        # forces a hard reload — the browser is currently
+                        # displaying the HTTP-served compile/runtime error
+                        # page (a different document with its own <head>),
+                        # and the WS reconnect's init resolves the path
+                        # successfully against the router's pre-break page
+                        # class, so the flag would otherwise stay clear.
+                        # Morphing the recovered page HTML into the error
+                        # DOM would leak the error template's <head>+styles
+                        # into the host app.
+                        self._connection_in_error.add(connection)
                         message_bytes = msgpack.packb({"type": "reload"})
                         await connection.send_bytes(message_bytes)
                 else:

--- a/packages/pywire/src/pywire/runtime/websocket.py
+++ b/packages/pywire/src/pywire/runtime/websocket.py
@@ -1045,9 +1045,7 @@ class WebSocketHandler:
                 # the browser fetches a clean document for the URL it's
                 # already showing.
                 if connection in self._connection_in_error:
-                    await connection.send_bytes(
-                        msgpack.packb({"type": "reload"})
-                    )
+                    await connection.send_bytes(msgpack.packb({"type": "reload"}))
                     self._connection_in_error.discard(connection)
                     continue
 
@@ -1059,9 +1057,7 @@ class WebSocketHandler:
                         type(old_page), "__is_compile_error_page__", False
                     )
                     if is_error_page:
-                        await connection.send_bytes(
-                            msgpack.packb({"type": "reload"})
-                        )
+                        await connection.send_bytes(msgpack.packb({"type": "reload"}))
                         continue
 
                     try:

--- a/packages/pywire/src/pywire/templates/error/compile_error.html.j2
+++ b/packages/pywire/src/pywire/templates/error/compile_error.html.j2
@@ -1,76 +1,259 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
-    <title>{{ title }}</title>
-    <style>
-        :root {
-            --bg-color: #1a1a1a;
-            --text-color: #e0e0e0;
-            --accent-color: #ff6b6b;
-            --secondary-color: #aaa;
-            --code-bg: #222;
-            --border-color: #333;
-            --highlight-bg: #3c1e1e;
-            --highlight-text: #ffcccc;
-            --highlight-border: #ff6b6b;
-            --file-color: #ffd43b;
-        }
-        body {
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-            background: var(--bg-color);
-            color: var(--text-color);
-            margin: 0;
-            padding: 20px;
-            line-height: 1.5;
-        }
-        .container { max-width: 1000px; margin: 0 auto; }
-        .header-block { border-bottom: 1px solid var(--border-color); padding-bottom: 20px; margin-bottom: 20px; }
-        h1 { color: var(--accent-color); font-size: 24px; margin-bottom: 5px; margin-top: 0; }
-        h3 { color: var(--secondary-color); font-size: 16px; margin-top: 30px; margin-bottom: 10px; }
-        .exc-msg { font-size: 18px; color: #fff; margin-bottom: 20px; font-weight: 500; white-space: pre-wrap; font-family: monospace; }
-        .error-location { background: #2d2d2d; border-radius: 8px; padding: 15px; margin-bottom: 20px; border-left: 4px solid var(--accent-color); }
-        .file-info { color: var(--file-color); font-family: monospace; font-size: 14px; margin-bottom: 10px; }
-        .code-context { padding: 10px 0; background: var(--code-bg); font-family: "Fira Code", monospace; font-size: 13px; overflow-x: auto; border-radius: 4px; }
-        .line { padding: 2px 15px; color: #888; display: flex; }
-        .line-current { padding: 2px 15px; background: var(--highlight-bg); color: var(--highlight-text); display: flex; border-left: 3px solid var(--highlight-border); }
-        .line-num { width: 40px; text-align: right; margin-right: 15px; opacity: 0.5; user-select: none; }
-        .code { white-space: pre; }
-        .traceback-section { margin-top: 20px; }
-        .traceback { background: var(--code-bg); padding: 15px; border-radius: 8px; font-size: 12px; overflow-x: auto; color: #ccc; white-space: pre-wrap; word-break: break-word; }
-    </style>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{{ title }}</title>
+<style>
+/* =====================================================================
+   PyWire built-in compile-error page.
+   Tokens mirror packages/pywire-design-system/colors_and_type.css —
+   "Two worlds, one wire": Lab (light) ↔ Void (dark) along the L axis,
+   one OKLCH cyan ladder for accents, error red for the signal-of-pain.
+   Self-contained: no external fonts, no external CSS.
+   ===================================================================== */
+:root {
+  color-scheme: light dark;
+
+  --color-wire-90: oklch(89% 0.13 195);
+  --color-wire-65: oklch(65% 0.13 195);
+  --color-wire-55: oklch(55% 0.13 195);
+  --color-wire-25: oklch(25% 0.13 195);
+  --color-wire-95: oklch(95% 0.05 195);
+
+  --color-error: #ff0055;
+  --color-warning: #ffd343;
+
+  /* Lab (light) */
+  --bg:           oklch(99%  0.005 250);
+  --bg-surface:   oklch(97.5% 0.006 250);
+  --bg-surface-2: oklch(95%  0.008 250);
+  --fg:           oklch(20%  0.040 250);
+  --fg-muted:     oklch(48%  0.025 250);
+  --border:       oklch(89%  0.010 250);
+  --accent:       var(--color-wire-65);
+  --accent-bg:    var(--color-wire-95);
+  --error-bg:     oklch(96% 0.04 10);
+  --error-border: oklch(78% 0.18 10);
+  --grid-line:    rgba(14, 21, 37, 0.06);
+
+  --font-sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  --font-mono: "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, monospace;
+
+  --radius-s:  4px;
+  --radius-m:  8px;
+  --radius-l:  12px;
+
+  --space-2xs: 0.5rem;
+  --space-xs:  0.75rem;
+  --space-s:   1rem;
+  --space-m:   1.5rem;
+  --space-l:   2rem;
+  --space-xl:  3rem;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg:           oklch(11%  0.010 250);
+    --bg-surface:   oklch(15%  0.012 250);
+    --bg-surface-2: oklch(20%  0.015 250);
+    --fg:           oklch(92%  0.012 250);
+    --fg-muted:     oklch(66%  0.020 250);
+    --border:       oklch(28%  0.018 250);
+    --accent:       var(--color-wire-90);
+    --accent-bg:    var(--color-wire-25);
+    --error-bg:     oklch(22% 0.10 10);
+    --error-border: oklch(55% 0.20 10);
+    --grid-line:    rgba(227, 230, 238, 0.05);
+  }
+}
+
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body {
+  font-family: var(--font-sans);
+  background: var(--bg);
+  background-image:
+    linear-gradient(var(--grid-line) 1px, transparent 1px),
+    linear-gradient(90deg, var(--grid-line) 1px, transparent 1px);
+  background-size: 32px 32px;
+  color: var(--fg);
+  line-height: 1.5;
+  min-height: 100vh;
+  padding: var(--space-xl) var(--space-s);
+}
+
+.container {
+  max-width: 1040px;
+  margin: 0 auto;
+}
+
+.eyebrow {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--color-error);
+  font-weight: 500;
+  margin: 0 0 var(--space-2xs);
+}
+
+h1 {
+  font-size: clamp(1.73rem, 1.56rem + 0.82vw, 2.20rem);
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  line-height: 1.15;
+  text-wrap: balance;
+  margin: 0 0 var(--space-l);
+  color: var(--fg);
+}
+
+.error-card {
+  background: var(--error-bg);
+  border: 1px solid var(--error-border);
+  border-radius: var(--radius-l);
+  padding: var(--space-m);
+  margin-bottom: var(--space-l);
+}
+
+.file-info {
+  font-family: var(--font-mono);
+  font-size: 0.875rem;
+  color: var(--color-error);
+  margin: 0 0 var(--space-2xs);
+  word-break: break-all;
+}
+
+.exc-msg {
+  font-family: var(--font-mono);
+  font-size: 1rem;
+  color: var(--fg);
+  margin: 0;
+  white-space: pre-wrap;
+  text-wrap: pretty;
+}
+
+.section-label {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--fg-muted);
+  font-weight: 500;
+  margin: var(--space-l) 0 var(--space-xs);
+}
+
+.code-window {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-l);
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+  line-height: 1.6;
+  overflow: hidden;
+}
+.code-window-chrome {
+  display: flex;
+  gap: 0.4rem;
+  padding: 0.65rem 1rem;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-surface-2);
+}
+.code-window-chrome span {
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  display: inline-block;
+}
+.dot-r { background: #ff5f57; }
+.dot-y { background: #febc2e; }
+.dot-g { background: #28c840; }
+
+.code-context {
+  padding: var(--space-xs) 0;
+  overflow-x: auto;
+}
+.line, .line-current {
+  display: flex;
+  padding: 0.1rem var(--space-s);
+  white-space: pre;
+}
+.line { color: var(--fg-muted); }
+.line-current {
+  background: var(--accent-bg);
+  color: var(--fg);
+  border-left: 3px solid var(--color-error);
+  padding-left: calc(var(--space-s) - 3px);
+}
+.line-num {
+  width: 3ch;
+  text-align: right;
+  margin-right: var(--space-s);
+  opacity: 0.55;
+  user-select: none;
+}
+.code { white-space: pre; }
+
+.traceback {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-l);
+  padding: var(--space-s);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  line-height: 1.6;
+  color: var(--fg-muted);
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-x: auto;
+  margin: 0;
+}
+
+.brand {
+  margin-top: var(--space-xl);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--fg-muted);
+  text-transform: lowercase;
+  letter-spacing: 0.04em;
+}
+.brand-mark { color: var(--accent); }
+</style>
 </head>
 <body>
-    <div class="container">
-        <div class="header-block">
-            <h1>{{ title }}</h1>
-        </div>
+<div class="container">
+  <p class="eyebrow">{{ title }}</p>
+  <h1>{{ tagline }}</h1>
 
-        <div class="error-location">
-            <div class="file-info">{{ file_display }}{% if error_line %}:{{ error_line }}{% endif %}</div>
-            <div class="exc-msg">{{ error_message }}</div>
-        </div>
+  <div class="error-card">
+    <p class="file-info">{{ file_display }}{% if error_line %}:{{ error_line }}{% endif %}</p>
+    <p class="exc-msg">{{ error_message }}</p>
+  </div>
 
-        {% if context_lines %}
-        <div class="code-context">
-            {% for line in context_lines %}
-            <div class="{% if line.is_current %}line-current{% else %}line{% endif %}">
-                <span class="line-num">{{ line.num }}</span>
-                <span class="code">{{ line.content }}</span>
-            </div>
-            {% endfor %}
-        </div>
-        {% endif %}
-
-        {% if traceback_text %}
-        <div class="traceback-section">
-            <h3>Full Traceback</h3>
-            <pre class="traceback">{{ traceback_text }}</pre>
-        </div>
-        {% endif %}
-
+  {% if context_lines %}
+  <p class="section-label">Source</p>
+  <div class="code-window">
+    <div class="code-window-chrome">
+      <span class="dot-r"></span><span class="dot-y"></span><span class="dot-g"></span>
     </div>
-    {% if script_url %}
-    <script src="{{ script_url }}"></script>
-    {% endif %}
+    <div class="code-context">
+      {% for line in context_lines %}
+      <div class="{% if line.is_current %}line-current{% else %}line{% endif %}">
+        <span class="line-num">{{ line.num }}</span><span class="code">{{ line.content }}</span>
+      </div>
+      {% endfor %}
+    </div>
+  </div>
+  {% endif %}
+
+  {% if traceback_text %}
+  <p class="section-label">Traceback</p>
+  <pre class="traceback">{{ traceback_text }}</pre>
+  {% endif %}
+
+  <p class="brand"><span class="brand-mark">●</span> pywire</p>
+</div>
+{% if script_url %}
+<script src="{{ script_url }}"></script>
+{% endif %}
 </body>
 </html>

--- a/packages/pywire/src/pywire/templates/error/default.wire
+++ b/packages/pywire/src/pywire/templates/error/default.wire
@@ -1,92 +1,218 @@
 !no_spa
 
+---
+import random
+
+# Tagline pools — random electricity/wire puns per error category.
+# Keep them short, technical, never cute. Sentence case, period.
+_TAGLINES_404 = [
+    "The wire ends here.",
+    "Dead conductor.",
+    "Open circuit.",
+    "End of the line.",
+    "Trace severed.",
+    "Signal lost in transit.",
+    "Off the grid.",
+    "No voltage past this point.",
+]
+_TAGLINES_500 = [
+    "The wire shorted.",
+    "Sparks flew.",
+    "Magic smoke escaped.",
+    "Fuse blew.",
+    "Circuit overloaded.",
+    "Ground fault detected.",
+    "Insulation failed.",
+    "Capacitor sang its last.",
+]
+_TAGLINES_OTHER = [
+    "Brownout.",
+    "Voltage drop.",
+    "Signal interrupted.",
+    "Conductor fatigued.",
+    "Phase out of sync.",
+    "Wire crossed.",
+]
+
+def pick_tagline():
+    if error_code == 404:
+        return random.choice(_TAGLINES_404)
+    if error_code == 500:
+        return random.choice(_TAGLINES_500)
+    return random.choice(_TAGLINES_OTHER)
+---
+
 <style>
-    :root {
-        --bg: #1a1a1a;
-        --text: #e0e0e0;
-        --accent: #ff6b6b;
-        --secondary: #aaa;
-        --border: #333;
-        --code-bg: #222;
-    }
+    /* Tokens mirror packages/pywire-design-system/colors_and_type.css.
+       Self-contained: no external fonts, no external CSS.
+       All rules are scoped to .pw-error-page so the styles cannot leak
+       into the host app's body or other tokens after SPA navigation. */
+    .pw-error-page {
+        color-scheme: light dark;
 
-    body {
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-        background: var(--bg);
-        color: var(--text);
-        margin: 0;
-        padding: 40px 20px;
+        --pw-wire-90: oklch(89% 0.13 195);
+        --pw-wire-65: oklch(65% 0.13 195);
+        --pw-wire-55: oklch(55% 0.13 195);
+        --pw-wire-25: oklch(25% 0.13 195);
+        --pw-wire-95: oklch(95% 0.05 195);
+
+        --pw-bg:         oklch(99%  0.005 250);
+        --pw-bg-surface: oklch(97.5% 0.006 250);
+        --pw-fg:         oklch(20%  0.040 250);
+        --pw-fg-muted:   oklch(48%  0.025 250);
+        --pw-border:     oklch(89%  0.010 250);
+        --pw-accent:     var(--pw-wire-65);
+        --pw-accent-bg:  var(--pw-wire-95);
+        --pw-link:       var(--pw-wire-55);
+        --pw-link-hover: var(--pw-wire-65);
+        --pw-grid-line:  rgba(14, 21, 37, 0.06);
+
+        --pw-font-sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+        --pw-font-mono: "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, monospace;
+
+        font-family: var(--pw-font-sans);
+        background: var(--pw-bg);
+        background-image:
+            linear-gradient(var(--pw-grid-line) 1px, transparent 1px),
+            linear-gradient(90deg, var(--pw-grid-line) 1px, transparent 1px);
+        background-size: 32px 32px;
+        color: var(--pw-fg);
+        min-height: 100vh;
         line-height: 1.5;
+        display: grid;
+        place-items: center;
+        padding: 3rem 1rem;
+        margin: 0;
     }
 
-    .container {
-        max-width: 800px;
-        margin: 0 auto;
+    @media (prefers-color-scheme: dark) {
+        .pw-error-page {
+            --pw-bg:         oklch(11%  0.010 250);
+            --pw-bg-surface: oklch(15%  0.012 250);
+            --pw-fg:         oklch(92%  0.012 250);
+            --pw-fg-muted:   oklch(66%  0.020 250);
+            --pw-border:     oklch(28%  0.018 250);
+            --pw-accent:     var(--pw-wire-90);
+            --pw-accent-bg:  var(--pw-wire-25);
+            --pw-link:       var(--pw-wire-90);
+            --pw-link-hover: oklch(94% 0.10 195);
+            --pw-grid-line:  rgba(227, 230, 238, 0.05);
+        }
     }
 
-    .error-code {
-        font-size: 5rem;
-        font-weight: 700;
-        color: var(--accent);
+    .pw-error-page, .pw-error-page *, .pw-error-page *::before, .pw-error-page *::after {
+        box-sizing: border-box;
+    }
+
+    .pw-error-page .container {
+        max-width: 720px;
+        width: 100%;
+    }
+
+    .pw-error-page .eyebrow {
+        font-family: var(--pw-font-mono);
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        color: var(--pw-accent);
+        font-weight: 500;
+        margin: 0 0 0.5rem;
+    }
+
+    .pw-error-page .error-code {
+        font-family: var(--pw-font-mono);
+        font-size: clamp(3.58rem, 2.97rem + 3.07vw, 5.35rem);
+        font-weight: 600;
+        color: var(--pw-fg);
         margin: 0;
         line-height: 1;
+        letter-spacing: -0.04em;
     }
 
-    .error-title {
-        font-size: 1.5rem;
-        color: var(--text);
-        margin: 0.5rem 0 1.5rem;
+    .pw-error-page .error-title {
+        font-size: clamp(1.44rem, 1.33rem + 0.55vw, 1.76rem);
+        font-weight: 600;
+        color: var(--pw-fg);
+        margin: 0.75rem 0 1.25rem;
+        text-wrap: balance;
+        line-height: 1.15;
     }
 
-    .error-message {
-        color: var(--secondary);
+    .pw-error-page .error-message {
+        color: var(--pw-fg-muted);
         font-size: 1rem;
-        margin-bottom: 2rem;
+        margin: 0 0 2rem;
+        text-wrap: pretty;
     }
 
-    .trace-section {
-        margin-top: 2rem;
+    .pw-error-page .home-link {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        color: var(--pw-link);
+        text-decoration: underline;
+        text-underline-offset: 0.25em;
+        font-size: 0.95rem;
+        transition: color 200ms cubic-bezier(0.16, 1, 0.3, 1);
     }
+    .pw-error-page .home-link:hover { color: var(--pw-link-hover); }
 
-    .trace-section h3 {
-        color: var(--secondary);
-        font-size: 0.875rem;
-        text-transform: uppercase;
-        letter-spacing: 0.05em;
-        margin-bottom: 0.75rem;
-    }
+    .pw-error-page .trace-section { margin-top: 3rem; }
 
-    .trace {
-        background: var(--code-bg);
-        border: 1px solid var(--border);
-        border-radius: 6px;
-        padding: 1rem;
-        font-family: "Fira Code", "Cascadia Code", monospace;
+    .pw-error-page .trace-section-label {
+        font-family: var(--pw-font-mono);
         font-size: 0.75rem;
-        color: #ccc;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        color: var(--pw-fg-muted);
+        font-weight: 500;
+        margin: 0 0 0.75rem;
+    }
+
+    .pw-error-page .trace {
+        background: var(--pw-bg-surface);
+        border: 1px solid var(--pw-border);
+        border-radius: 12px;
+        padding: 1rem 1.25rem;
+        font-family: var(--pw-font-mono);
+        font-size: 0.75rem;
+        line-height: 1.6;
+        color: var(--pw-fg-muted);
         white-space: pre-wrap;
         word-break: break-word;
         overflow-x: auto;
+        margin: 0;
     }
+
+    .pw-error-page .brand {
+        margin-top: 3rem;
+        font-family: var(--pw-font-mono);
+        font-size: 0.75rem;
+        color: var(--pw-fg-muted);
+        text-transform: lowercase;
+        letter-spacing: 0.04em;
+    }
+    .pw-error-page .brand-mark { color: var(--pw-accent); }
 </style>
 
-<div class="container">
-    <p class="error-code">{error_code}</p>
+<div class="pw-error-page">
+    <div class="container">
+        <p class="eyebrow">Error {error_code}</p>
+        <p class="error-code">{error_code}</p>
 
-    {$if error_code == 404}
-    <h1 class="error-title">Page Not Found</h1>
-    {$elif error_code == 500}
-    <h1 class="error-title">Server Error</h1>
-    {$else}
-    <h1 class="error-title">Error {error_code}</h1>
-    {/if}
+        <h1 class="error-title">{pick_tagline()}</h1>
 
-    <p class="error-message">{error_message}</p>
+        <p class="error-message">{error_message}</p>
 
-    {$if error_trace}
-    <div class="trace-section">
-        <h3>Traceback</h3>
-        <pre class="trace">{error_trace}</pre>
+        <a class="home-link" href="/">← Back to safety</a>
+
+        {$if error_trace}
+        <div class="trace-section">
+            <p class="trace-section-label">Traceback</p>
+            <pre class="trace">{error_trace}</pre>
+        </div>
+        {/if}
+
+        <p class="brand"><span class="brand-mark">●</span> pywire</p>
     </div>
-    {/if}
 </div>

--- a/packages/pywire/src/pywire/templates/reconnect/default.html
+++ b/packages/pywire/src/pywire/templates/reconnect/default.html
@@ -1,23 +1,35 @@
 <style>
-/* PyWire reconnect overlay – customise via CSS custom properties */
+/* PyWire reconnect overlay — tokens mirror the design system
+   (packages/pywire-design-system/colors_and_type.css). Self-contained;
+   customisable via CSS custom properties on #_pywire_reconnect_overlay. */
 #_pywire_reconnect_overlay {
-  --pw-reconnect-backdrop: rgba(0, 0, 0, 0.45);
-  --pw-reconnect-card-bg: #fff;
-  --pw-reconnect-card-shadow: 0 4px 24px rgba(0, 0, 0, 0.18);
-  --pw-reconnect-text: #222;
-  --pw-reconnect-muted: #888;
-  --pw-reconnect-accent: #3b82f6;
-  --pw-reconnect-btn-bg: #3b82f6;
-  --pw-reconnect-btn-text: #fff;
+  --pw-reconnect-backdrop: hsl(0 100% 0% / 0.55);
+  --pw-reconnect-card-bg: oklch(99% 0.005 250);
+  --pw-reconnect-card-border: oklch(89% 0.010 250);
+  --pw-reconnect-text: oklch(20% 0.040 250);
+  --pw-reconnect-muted: oklch(48% 0.025 250);
+  --pw-reconnect-accent: oklch(65% 0.13 195);
+  --pw-reconnect-accent-hover: oklch(55% 0.13 195);
+  --pw-reconnect-accent-bg: oklch(95% 0.05 195);
+  --pw-reconnect-fg-on-accent: #ffffff;
+  --pw-reconnect-glow: 0 0 14px rgba(0, 200, 220, 0.32);
+  --pw-reconnect-shadow: 0 1px 2px rgba(14, 21, 37, 0.05), 0 4px 14px rgba(14, 21, 37, 0.06);
+  --pw-reconnect-font-sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  --pw-reconnect-font-mono: "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 
 @media (prefers-color-scheme: dark) {
   #_pywire_reconnect_overlay {
-    --pw-reconnect-backdrop: rgba(0, 0, 0, 0.6);
-    --pw-reconnect-card-bg: #1e1e2e;
-    --pw-reconnect-card-shadow: 0 4px 24px rgba(0, 0, 0, 0.4);
-    --pw-reconnect-text: #e0e0e0;
-    --pw-reconnect-muted: #999;
+    --pw-reconnect-backdrop: hsl(0 100% 0% / 0.75);
+    --pw-reconnect-card-bg: oklch(15% 0.012 250);
+    --pw-reconnect-card-border: oklch(28% 0.018 250);
+    --pw-reconnect-text: oklch(92% 0.012 250);
+    --pw-reconnect-muted: oklch(66% 0.020 250);
+    --pw-reconnect-accent: oklch(89% 0.13 195);
+    --pw-reconnect-accent-hover: oklch(94% 0.10 195);
+    --pw-reconnect-accent-bg: oklch(25% 0.13 195);
+    --pw-reconnect-fg-on-accent: oklch(15% 0.04 195);
+    --pw-reconnect-shadow: var(--pw-reconnect-glow);
   }
 }
 
@@ -29,43 +41,59 @@
   align-items: center;
   justify-content: center;
   background: var(--pw-reconnect-backdrop);
+  backdrop-filter: blur(3px);
+  -webkit-backdrop-filter: blur(3px);
 }
 
 #_pywire_reconnect_overlay .pw-reconnect-card {
   background: var(--pw-reconnect-card-bg);
-  box-shadow: var(--pw-reconnect-card-shadow);
+  border: 1px solid var(--pw-reconnect-card-border);
+  box-shadow: var(--pw-reconnect-shadow);
   border-radius: 12px;
-  padding: 2rem 2.5rem;
+  padding: 2rem 2.25rem;
   text-align: center;
-  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-family: var(--pw-reconnect-font-sans);
   color: var(--pw-reconnect-text);
-  max-width: 340px;
+  max-width: 360px;
   width: 90vw;
 }
 
-/* Spinner */
+#_pywire_reconnect_overlay .pw-reconnect-eyebrow {
+  font-family: var(--pw-reconnect-font-mono);
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--pw-reconnect-accent);
+  font-weight: 500;
+  margin: 0 0 0.75rem;
+}
+
+/* Spinner — constant-rate (linear) rotation, no easing spikes. */
 #_pywire_reconnect_overlay .pw-reconnect-spinner {
-  width: 36px;
-  height: 36px;
+  width: 32px;
+  height: 32px;
   margin: 0 auto 1rem;
-  border: 3px solid var(--pw-reconnect-muted);
+  border: 2.5px solid var(--pw-reconnect-card-border);
   border-top-color: var(--pw-reconnect-accent);
   border-radius: 50%;
-  animation: pw-spin 0.8s linear infinite;
+  animation: pw-spin 1.2s linear infinite;
 }
 
-@keyframes pw-spin {
-  to { transform: rotate(360deg); }
+@keyframes pw-spin { to { transform: rotate(360deg); } }
+
+@media (prefers-reduced-motion: reduce) {
+  #_pywire_reconnect_overlay .pw-reconnect-spinner {
+    animation: none;
+  }
 }
 
-/* Messages */
 #_pywire_reconnect_overlay .pw-reconnect-message {
-  margin: 0 0 0.5rem;
+  margin: 0 0 0.25rem;
   font-size: 1rem;
   line-height: 1.4;
+  color: var(--pw-reconnect-text);
 }
 
-/* State-driven visibility */
 #_pywire_reconnect_overlay .pw-reconnect-msg-failed,
 #_pywire_reconnect_overlay .pw-reconnect-reload {
   display: none;
@@ -81,27 +109,31 @@
   display: block;
 }
 
-/* Reload button */
 #_pywire_reconnect_overlay .pw-reconnect-reload {
-  margin-top: 1rem;
-  padding: 0.5rem 1.5rem;
+  margin: 1rem auto 0;
+  padding: 0.55rem 1.5rem;
   border: none;
-  border-radius: 6px;
+  border-radius: 8px;
+  font-family: var(--pw-reconnect-font-sans);
   font-size: 0.9rem;
   font-weight: 500;
   cursor: pointer;
-  background: var(--pw-reconnect-btn-bg);
-  color: var(--pw-reconnect-btn-text);
-  transition: opacity 0.15s;
+  background: var(--pw-reconnect-accent);
+  color: var(--pw-reconnect-fg-on-accent);
+  transition: background-color 200ms cubic-bezier(0.16, 1, 0.3, 1);
 }
-
 #_pywire_reconnect_overlay .pw-reconnect-reload:hover {
-  opacity: 0.85;
+  background: var(--pw-reconnect-accent-hover);
+}
+#_pywire_reconnect_overlay .pw-reconnect-reload:focus-visible {
+  outline: 3px solid var(--pw-reconnect-accent);
+  outline-offset: 2px;
 }
 </style>
 
 <div class="pw-reconnect-backdrop">
   <div class="pw-reconnect-card">
+    <p class="pw-reconnect-eyebrow">● pywire</p>
     <div class="pw-reconnect-spinner" aria-hidden="true"></div>
     <p class="pw-reconnect-message pw-reconnect-msg-reconnecting">Reconnecting&hellip;</p>
     <p class="pw-reconnect-message pw-reconnect-msg-failed">Connection lost</p>

--- a/packages/pywire/src/pywire/templates/reconnect/default.html
+++ b/packages/pywire/src/pywire/templates/reconnect/default.html
@@ -136,7 +136,7 @@
     <p class="pw-reconnect-eyebrow">● pywire</p>
     <div class="pw-reconnect-spinner" aria-hidden="true"></div>
     <p class="pw-reconnect-message pw-reconnect-msg-reconnecting">Reconnecting&hellip;</p>
-    <p class="pw-reconnect-message pw-reconnect-msg-failed">Connection lost</p>
+    <p class="pw-reconnect-message pw-reconnect-msg-failed">Connection failed.<br/>Try reloading.</p>
     <button class="pw-reconnect-reload" onclick="location.reload()">Reload</button>
   </div>
 </div>

--- a/packages/pywire/tests/test_compile_error.py
+++ b/packages/pywire/tests/test_compile_error.py
@@ -63,7 +63,7 @@ async def test_compile_error_page_generic_exception(
 
     assert "Compilation Error" in content
     assert "ValueError: Something went wrong" in content
-    assert "Full Traceback" in content
+    assert "Traceback" in content
     assert "ValueError" in content
 
 
@@ -89,7 +89,7 @@ async def test_compile_error_page_traceback_inference(
     content = bytes(response.body).decode()
 
     assert "RuntimeError: Fail" in content
-    assert "Full Traceback" in content
+    assert "Traceback" in content
 
 
 @pytest.mark.asyncio

--- a/packages/pywire/tests/test_compiler_sourcemap.py
+++ b/packages/pywire/tests/test_compiler_sourcemap.py
@@ -12,9 +12,11 @@ class TestCompilerSourceMap:
         """Verify runtime errors in python blocks point to correct lines."""
         loader = PageLoader()
 
-        # Line 1: raise ValueError("Boom")
-        # Line 2: ---
-        # Line 3: <h1>Test</h1>
+        # Line 1: ---
+        # Line 2: raise ValueError("Boom")
+        # Line 3: ---
+        # Line 4: (blank)
+        # Line 5: <h1>Test</h1>
         source = """---
 raise ValueError("Boom")
 ---
@@ -38,9 +40,9 @@ raise ValueError("Boom")
 
             error_frame = frames[-1]
 
-            # raise on line 1
-            assert error_frame.lineno == 1, (
-                f"Raise should be on line 1, got {error_frame.lineno}"
+            # raise is on .wire line 2 (after opening --- fence on line 1)
+            assert error_frame.lineno == 2, (
+                f"Raise should be on line 2, got {error_frame.lineno}"
             )
 
     @pytest.mark.asyncio

--- a/packages/pywire/tests/test_custom_errors.py
+++ b/packages/pywire/tests/test_custom_errors.py
@@ -13,7 +13,9 @@ def test_default_404_no_pages_dir(tmp_path: Path) -> None:
 
     response = client.get("/not-found")
     assert response.status_code == 404
-    assert "Not Found" in response.text
+    # Default branded error page renders the 404 code prominently.
+    assert "404" in response.text
+    assert "wire" in response.text.lower()
 
 
 def test_custom_error_page(tmp_path: Path) -> None:

--- a/packages/pywire/tests/test_hot_reload_handler.py
+++ b/packages/pywire/tests/test_hot_reload_handler.py
@@ -122,6 +122,7 @@ class TestBroadcastReloadOrdering(unittest.TestCase):
         handler.active_connections = set()
         handler.connection_pages = {}
         handler.session_ids = {}
+        handler._connection_in_error = set()
 
         # Mock connection
         mock_ws = AsyncMock()
@@ -171,6 +172,7 @@ class TestBroadcastReloadOrdering(unittest.TestCase):
         handler.active_connections = set()
         handler.connection_pages = {}
         handler.session_ids = {}
+        handler._connection_in_error = set()
 
         mock_ws = AsyncMock()
         handler.active_connections.add(mock_ws)

--- a/uv.lock
+++ b/uv.lock
@@ -2078,7 +2078,7 @@ requires-dist = [
 
 [[package]]
 name = "pywire-parser"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "packages/pywire-parser" }
 dependencies = [
     { name = "tree-sitter" },


### PR DESCRIPTION
## Summary

Four-part fix to the PyWire error / connection-failure system:

- **`pywire-parser` line-number alignment (#200)** — python content extracted from a `.wire` file's fenced section started at AST line 1 regardless of where the fence sat in the source, so compile errors and runtime tracebacks reported lines 1-N too low. Track the python fence's start row in `ParsedDocument.python_start_line` and apply it as an offset to `PyWireSyntaxError.line` and `ast.increment_lineno(...)`. Bumps version floors in `pywire` and `pywire-language-server` (pyproject + `_compat.py`) to `pywire-parser>=0.8.0`.
- **Built-in template rebrand** — error/compile/reconnect templates rewritten to the PyWire Design System (OKLCH "Wire" cyan ladder, Lab/Void modes, mono eyebrows, engineering-grid backdrop, macOS-chrome code window). Random tagline pools per error category (404, 500, syntax, runtime), picked per render. Reconnect spinner rotates at constant linear speed and respects `prefers-reduced-motion`.
- **SPA error-state leak** — when a `.wire` file broke and was then fixed, hot-reload morphed the recovered page HTML into the displayed error DOM, leaking the error template's `<head>`/`<style>` into the host app (Pico stylesheets gone, engineering grid stuck on body). Three paths now force a hard reload instead of a morph:
  1. WS `relocate` returning 4xx/5xx → `{type: reload}` with cookie commands applied first.
  2. Hot reload while the displayed page is an error page (`isinstance(old_page, ErrorBasePage)` *or* `__is_compile_error_page__` class marker on the dynamically-created `ModeAwareErrorPage`).
  3. `httpNavigate` / `httpFormSubmit` non-OK response → `window.location.href` fallback.

  A new per-connection `_connection_in_error` set tracks WS connections whose last response was an error so the *next* `broadcast_reload` also forces a hard reload.
- **WS reconnect cap + "failed" overlay state** — the overlay's "failed" state was unreachable in practice: its internal timer flipped to failed after N intervals, but the transport reconnected forever, so the console kept spamming `WebSocket connection ... failed` long past the give-up point and the user never saw a Reload button. `WebSocketTransport` now enforces `maxReconnectAttempts` (default 10), stops scheduling, fires `onGiveUp`, and logs a single warn. `ReconnectOverlay` drops its scheduler — state is now transport-driven via `markFailed()`. `socket.onerror` only logs on initial connect (not reconnect backoff) and downgrades to `warn`.

Closes #200.

## Test plan

- [x] `cd packages/pywire && uv run --extra dev pytest -q` — Python tests pass
- [x] `pnpm -C packages/pywire/src/pywire/client test` — 58 client tests pass
- [x] `pnpm -C packages/pywire/src/pywire/client run typecheck` — clean
- [x] Manual: break `index.wire` → save → fix → save. Recovered page's `<head>` is clean (Pico loaded, no engineering grid).
- [x] Compile-error page reports correct source line.
- [x] Reconnect spinner rotates at constant linear speed.
- [ ] Manual: kill the dev server and confirm the overlay flips to "Connection failed. Try reloading." after 10 attempts, with no further `WebSocket error` console spam.