### PR TITLE
fix: re-record breaking change for release-please after squash-merge

### DIFF
--- a/packages/pywire-parser/src/pywire_parser/analysis/context.py
+++ b/packages/pywire-parser/src/pywire_parser/analysis/context.py
@@ -1,9 +1,13 @@
 """Per-file analysis context.
 
 A single pass over the Python AST collects simple name → kind bindings so
-individual rules don't each need to re-scan for wire/derived/store
+individual rules don't each need to re-scan for wire/derived/producer
 assignments. This is deliberately lightweight heuristics — not type
 inference. The ROADMAP covers real type-flow integration.
+
+Recognized factory kinds: wire, derived, effect, ref, producer. The
+former store kinds (writable, readable, store_derived) are gone — the
+downstream pywire package no longer ships those names.
 """
 
 from __future__ import annotations

--- a/packages/pywire/src/pywire/core/producer.py
+++ b/packages/pywire/src/pywire/core/producer.py
@@ -12,6 +12,15 @@ It may optionally return a no-arg cleanup function that runs on
 Producers participate in the same render-context tracking as `wire()`,
 so accessing `producer.value` inside a `.wire` template makes the
 region re-render whenever the producer pushes a new value.
+
+Migration from the removed Svelte-style stores API:
+
+- `writable(x)`        -> `wire(x)`
+- `store_derived(...)` -> `derived(...)` (auto-tracks deps)
+- `readable(x, fn)`    -> `producer(x, fn)`
+- `store.set(x)`       -> `wire.value = x`
+- `store.update(fn)`   -> `wire.value = fn(wire.value)`
+- `store.subscribe(cb)`-> `wire.subscribe(cb)` (same signature)
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

Recover the breaking-change attribution for #243. GitHub's squash-merge produced the commit subject `feat!: unify stores into wire/derived/producer (closes #228) (#243)` — release-please's parser failed on the second `(`:

> Commit could not be parsed: 20eecce... feat!: unify stores into wire/derived/producer (closes #228) (#243)
> error message: Error: unexpected token '(' at 41:20, valid tokens [)]

The result: PRs #244 (pywire-parser 0.7.1) and #245 (pywire 0.14.3) currently list only the unrelated bug fixes; the breaking change for the stores removal is not in either changelog.

This PR adds two parseable follow-up commits with `BREAKING CHANGE:` footers — one per affected package — that touch real files (per the no-empty-commits rule). Each commit edits a docstring in the package whose API broke; the pywire one also adds an inline migration table to `core/producer.py` so anyone landing in that file finds the migration.

After merge, release-please's next run should re-open #244 and #245 with the breaking change recorded under `### Features` / `### ⚠ BREAKING CHANGES` in each changelog.

## Root cause and prevention

The PR title contained `(closes #228)`. With squash-merge, GitHub appends ` (#PR_NUMBER)`, producing two parenthesized segments after the subject — release-please reads the second `(` as a malformed scope. Avoid `(...)` in PR titles when squash-merging; put issue refs in the body (`Closes #N`).

## Test plan

- [ ] CI green
- [ ] After merge, verify release-please's `pywire` and `pywire-parser` release PRs reflect the breaking change under "⚠ BREAKING CHANGES"