### PR TITLE
feat: pywire-observability — Request-ID, JSON logging, OTel, Sentry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
       cli: ${{ steps.filter.outputs.cli }}
       templates: ${{ steps.filter.outputs.templates }}
       auth: ${{ steps.filter.outputs.auth }}
+      observability: ${{ steps.filter.outputs.observability }}
       ls: ${{ steps.filter.outputs.ls }}
       vscode: ${{ steps.filter.outputs.vscode }}
       prettier: ${{ steps.filter.outputs.prettier }}
@@ -52,6 +53,8 @@ jobs:
               - 'packages/pywire-templates/**'
             auth:
               - 'packages/pywire-auth/**'
+            observability:
+              - 'packages/pywire-observability/**'
             ls:
               - 'packages/pywire-language-server/**'
             vscode:
@@ -162,6 +165,22 @@ jobs:
         run: uv sync
       - name: Run Checks
         run: cd packages/pywire-auth && ./scripts/check
+
+  # pywire-observability: request-ID propagation, JSON logging, OTel/Sentry recipes. Depends on pywire.
+  check-pywire-observability:
+    name: "Check PyWire Observability"
+    needs: changes
+    if: needs.changes.outputs.observability == 'true' || needs.changes.outputs.pywire == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - name: Sync Dependencies
+        run: uv sync
+      - name: Run Checks
+        run: cd packages/pywire-observability && ./scripts/check
 
   # Language Server: depends on pywire (runtime types), pywire-parser (analysis),
   # tree-sitter-pywire (via parser).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,8 @@ jobs:
       pywire-parser--tag_name: ${{ steps.release.outputs['packages/pywire-parser--tag_name'] }}
       pywire-auth--release_created: ${{ steps.release.outputs['packages/pywire-auth--release_created'] }}
       pywire-auth--tag_name: ${{ steps.release.outputs['packages/pywire-auth--tag_name'] }}
+      pywire-observability--release_created: ${{ steps.release.outputs['packages/pywire-observability--release_created'] }}
+      pywire-observability--tag_name: ${{ steps.release.outputs['packages/pywire-observability--tag_name'] }}
       pywire-cli--release_created: ${{ steps.release.outputs['packages/pywire-cli--release_created'] }}
       pywire-cli--tag_name: ${{ steps.release.outputs['packages/pywire-cli--tag_name'] }}
       pywire-templates--release_created: ${{ steps.release.outputs['packages/pywire-templates--release_created'] }}
@@ -72,6 +74,7 @@ jobs:
             "Check PyWire CLI"
             "Check PyWire Templates"
             "Check PyWire Auth"
+            "Check PyWire Observability"
             "Check Language Server"
             "Check VS Code Extension"
             "Check Prettier Plugin"
@@ -304,6 +307,23 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: packages/pywire-auth/dist/
+
+  # Build and publish pywire-observability (pure Python)
+  publish-pywire-observability:
+    name: "Publish pywire-observability to PyPI"
+    needs: release-please
+    if: needs.release-please.outputs.pywire-observability--release_created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv build --out-dir dist
+        working-directory: packages/pywire-observability
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: packages/pywire-observability/dist/
 
   # Publish pywire-cli to PyPI
   publish-pywire-cli:

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -3,6 +3,7 @@
   "packages/pywire": "0.14.3",
   "packages/pywire-parser": "0.7.1",
   "packages/pywire-auth": "0.3.0",
+  "packages/pywire-observability": "0.1.0",
   "packages/pywire-cli": "0.3.0",
   "packages/pywire-templates": "0.2.0",
   "packages/tree-sitter-pywire": "0.6.0",

--- a/packages/pywire-cli/pyproject.toml
+++ b/packages/pywire-cli/pyproject.toml
@@ -62,6 +62,10 @@ allowed-unresolved-imports = [
     "pywire_parser.**",
     "pywire_templates",
     "pywire_templates.**",
+    # Lazy-imported inside _maybe_enable_json_logging when users opt
+    # into `--log-format=json`. Not a hard runtime dep of the CLI.
+    "pywire_observability",
+    "pywire_observability.**",
 ]
 
 [[tool.ty.overrides]]

--- a/packages/pywire-cli/src/pywire_cli/main.py
+++ b/packages/pywire-cli/src/pywire_cli/main.py
@@ -257,16 +257,11 @@ def dev(
 ) -> None:
     """Start development server."""
     import asyncio
-    import os
 
     from pywire_cli.config import get_setting
     from pywire.runtime.dev_server import run_dev_server
 
-    effective_log_format = (
-        log_format or os.environ.get("PYWIRE_LOG_FORMAT", "text")
-    ).lower()
-    if effective_log_format == "json":
-        _enable_json_logging()
+    _maybe_enable_json_logging(log_format)
 
     # Resolve TUI setting: CLI flag > settings.toml > default (False)
     if tui is None:
@@ -583,15 +578,10 @@ def run(
 ) -> None:
     """Run production server using Uvicorn."""
     import multiprocessing
-    import os
 
     import uvicorn
 
-    effective_log_format = (
-        log_format or os.environ.get("PYWIRE_LOG_FORMAT", "text")
-    ).lower()
-    if effective_log_format == "json":
-        _enable_json_logging()
+    _maybe_enable_json_logging(log_format)
 
     if not app:
         app = _discover_app_str()
@@ -619,12 +609,24 @@ def run(
     )
 
 
-def _enable_json_logging() -> None:
-    """Activate JSON log output via pywire-observability.
+def _maybe_enable_json_logging(flag: Optional[str]) -> None:
+    """Resolve --log-format / PYWIRE_LOG_FORMAT and configure if json.
 
-    Falls back to a clear error message when the package isn't
-    installed — JSON logging is opt-in, so we don't bundle the dep.
+    Sets ``PYWIRE_LOG_FORMAT=json`` in the environment unconditionally
+    when JSON mode is selected so uvicorn workers (spawned with a
+    fresh interpreter) inherit the choice and re-run
+    :func:`pywire_observability.connect_observability` with json
+    logging on. The parent process also gets JSON logging immediately
+    so startup messages match worker output.
     """
+    import os
+
+    effective = (flag or os.environ.get("PYWIRE_LOG_FORMAT", "text")).lower()
+    if effective != "json":
+        return
+
+    os.environ["PYWIRE_LOG_FORMAT"] = "json"
+
     try:
         from pywire_observability.logging import configure_json_logging
     except ImportError as exc:

--- a/packages/pywire-cli/src/pywire_cli/main.py
+++ b/packages/pywire-cli/src/pywire_cli/main.py
@@ -236,6 +236,15 @@ cli.add_command(config_command)
 @click.option("--ssl-certfile", default=None, help="SSL certificate file")
 @click.option("--env-file", default=None, help="Environment configuration file")
 @click.option("--tui/--no-tui", default=None, help="Enable/disable TUI dashboard")
+@click.option(
+    "--log-format",
+    type=click.Choice(["text", "json"]),
+    default=None,
+    help=(
+        "Log output format. 'json' emits one JSON record per line. "
+        "Defaults to PYWIRE_LOG_FORMAT env var, or 'text' if unset."
+    ),
+)
 def dev(
     app: Optional[str],
     host: str,
@@ -244,12 +253,20 @@ def dev(
     ssl_certfile: Optional[str],
     env_file: Optional[str],
     tui: Optional[bool],
+    log_format: Optional[str],
 ) -> None:
     """Start development server."""
     import asyncio
+    import os
 
     from pywire_cli.config import get_setting
     from pywire.runtime.dev_server import run_dev_server
+
+    effective_log_format = (
+        log_format or os.environ.get("PYWIRE_LOG_FORMAT", "text")
+    ).lower()
+    if effective_log_format == "json":
+        _enable_json_logging()
 
     # Resolve TUI setting: CLI flag > settings.toml > default (False)
     if tui is None:
@@ -545,17 +562,36 @@ def check(
 @click.option("--port", default=8000, type=int, help="Port to bind to")
 @click.option("--workers", default=None, type=int, help="Number of worker processes")
 @click.option("--no-access-log", is_flag=True, help="Disable access logging")
+@click.option(
+    "--log-format",
+    type=click.Choice(["text", "json"]),
+    default=None,
+    help=(
+        "Log output format. 'json' emits one JSON record per line "
+        "(Datadog/ELK/Loki/CloudWatch compatible). Defaults to "
+        "PYWIRE_LOG_FORMAT env var, or 'text' if unset. Requires "
+        "pywire-observability to be installed for json mode."
+    ),
+)
 def run(
     app: Optional[str],
     host: str,
     port: int,
     workers: Optional[int],
     no_access_log: bool,
+    log_format: Optional[str],
 ) -> None:
     """Run production server using Uvicorn."""
     import multiprocessing
+    import os
 
     import uvicorn
+
+    effective_log_format = (
+        log_format or os.environ.get("PYWIRE_LOG_FORMAT", "text")
+    ).lower()
+    if effective_log_format == "json":
+        _enable_json_logging()
 
     if not app:
         app = _discover_app_str()
@@ -581,6 +617,22 @@ def run(
         access_log=not no_access_log,
         factory=False,
     )
+
+
+def _enable_json_logging() -> None:
+    """Activate JSON log output via pywire-observability.
+
+    Falls back to a clear error message when the package isn't
+    installed — JSON logging is opt-in, so we don't bundle the dep.
+    """
+    try:
+        from pywire_observability.logging import configure_json_logging
+    except ImportError as exc:
+        raise click.ClickException(
+            "pywire-observability is required for --log-format=json. "
+            "Install with: pip install pywire-observability"
+        ) from exc
+    configure_json_logging()
 
 
 def _print_skip_hint(

--- a/packages/pywire-language-server/src/pywire_language_server/transpiler.py
+++ b/packages/pywire-language-server/src/pywire_language_server/transpiler.py
@@ -705,6 +705,10 @@ class Transpiler:
         _append(
             "path = _PathNamespace()\nurl = _UrlNamespace()\nparams = _ParamsNamespace()\nquery = _QueryNamespace()\ndef navigate(path: str) -> None: ...\ndef asset(path: str) -> str: ...\ndef set_cookie(key: str, value: str = '', *, max_age: int | None = None, expires: int | None = None, path: str = '/', domain: str | None = None, secure: bool = False, httponly: bool = False, samesite: str | None = 'lax') -> None: ...\ndef delete_cookie(key: str, *, path: str = '/', domain: str | None = None) -> None: ...\n\n"
         )
+        # request_id is always present on BasePage (defaults to "" when
+        # pywire-observability isn't installed), so unconditional
+        # emission gives templates a known type for completion / hover.
+        _append("request_id: str\n\n")
         if self.has_auth:
             _append(
                 "from pywire.auth.principal import ClaimsPrincipal\nuser: ClaimsPrincipal\n\n"

--- a/packages/pywire-observability/CHANGELOG.md
+++ b/packages/pywire-observability/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to `pywire-observability` are documented here. This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and uses [release-please](https://github.com/googleapis/release-please) for automated releases.
+
+Initial release: request-ID propagation across HTTP and WebSocket scopes, JSON log formatter (Datadog/ELK/Loki/CloudWatch compatible), OpenTelemetry instrumentation helper, and Sentry integration recipe.
+
+## Unreleased
+
+_Release PR tracked by release-please._

--- a/packages/pywire-observability/README.md
+++ b/packages/pywire-observability/README.md
@@ -1,0 +1,99 @@
+# pywire-observability
+
+Request-ID propagation, JSON logging, OpenTelemetry, and Sentry recipes for PyWire apps.
+
+## Install
+
+```sh
+pip install pywire-observability
+```
+
+## Quick start
+
+```python
+from pywire import PyWire
+from pywire_observability import connect_observability
+
+app = PyWire(...)
+connect_observability(app, json_logging=True)
+```
+
+That's the full prod-ready loadout: request IDs propagate across HTTP and WebSocket scopes, every log line emits as JSON with the request/connection/event ID auto-attached, and HTTP-500s + WebSocket handler exceptions flow through the standard `pywire.*` logger hierarchy (so they reach any aggregator that consumes Python's `logging`).
+
+## What ships
+
+### Request-ID propagation
+
+`RequestIDMiddleware` reads inbound trace headers in priority order:
+
+1. `traceparent` (W3C Trace Context — the trace_id portion is preserved so OTel-aware backends auto-correlate logs to traces)
+2. `x-request-id`
+3. `x-correlation-id`
+4. Fresh `uuid4().hex` if none present
+
+The id is written to `scope["pywire_request_id"]` and the `request_id_ctx` ContextVar in `pywire.runtime.observability` for the duration of the request — log records emitted from anywhere in the request path (handlers, background tasks, render callbacks) automatically carry it. HTTP responses echo it back as `X-Request-ID` so downstream services can correlate.
+
+WebSocket connections get an extra `connection_id` (one per socket lifetime) and `event_id` (one per event handler call) so logs can correlate by socket, by single user action, or by both.
+
+### JSON logging
+
+`configure_json_logging()` (or `connect_observability(json_logging=True)`) replaces the root logger's handlers with a single `JSONFormatter` writing one JSON record per line:
+
+```json
+{"timestamp": "2026-05-05T14:32:01.234567+00:00", "level": "INFO", "logger": "pywire.runtime.app", "message": "Page rendered", "request_id": "...", "connection_id": "...", "event_id": "..."}
+```
+
+Compatible with Datadog, ELK, Loki, CloudWatch, Cloud Logging, and Azure Monitor — all auto-parse JSON-per-line stdout.
+
+Activate via:
+- `connect_observability(app, json_logging=True)` programmatically
+- `PYWIRE_LOG_FORMAT=json` env var (when using `pywire-cli`)
+- `pywire run --log-format=json` / `pywire dev --log-format=json` CLI flag
+
+### OpenTelemetry recipe
+
+```sh
+pip install opentelemetry-api opentelemetry-sdk \
+            opentelemetry-instrumentation-starlette \
+            opentelemetry-exporter-otlp
+```
+
+```python
+from pywire_observability.otel import instrument
+
+instrument(app)
+```
+
+Wires the standard Starlette ASGI instrumentation onto PyWire's inner Starlette app. HTTP requests + WebSocket upgrade handshakes are auto-spanned. Per-WS-event spans are not yet covered (see [#254](https://github.com/pywire/pywire/issues/254)). Internal ASGI replays are filtered out so the trace tree stays clean.
+
+### Sentry recipe
+
+```sh
+pip install 'sentry-sdk[starlette]'
+```
+
+```python
+from pywire_observability.sentry import init as init_sentry
+
+init_sentry(dsn=os.environ["SENTRY_DSN"], environment="prod")
+```
+
+Wires Sentry's `LoggingIntegration` (captures every `logger.exception(...)` — including the WS / HTTP-500 fixes pywire-observability ships) and `StarletteIntegration` (HTTP request context). Every captured event is auto-tagged with `pywire_request_id`, `pywire_connection_id`, and `pywire_event_id` when present.
+
+## What this fixes
+
+PyWire core previously logged WS handler exceptions with `print` + `traceback.print_exc()` — invisible to any logging-based aggregator (Sentry's `LoggingIntegration`, ELK forwarders, etc.). HTTP 500s were swallowed into the error page with no log call. Both paths now use `logger.exception(...)` so production failures reach observability infrastructure.
+
+## Configuration via environment
+
+| Variable | Default | Effect |
+|---|---|---|
+| `PYWIRE_LOG_FORMAT` | `text` | Set to `json` to activate JSON logging via the CLI flag default. |
+| `PYWIRE_LOG_LEVEL` | `WARNING` | Sets the level on the `pywire` logger (existing PyWire core var). |
+
+## Deferred to v0.2
+
+- Per-WebSocket-event OTel spans — [#254](https://github.com/pywire/pywire/issues/254)
+- Metrics surface (Prometheus / OTel meter) — [#255](https://github.com/pywire/pywire/issues/255)
+- Distributed-tracing-aware page state snapshots — [#256](https://github.com/pywire/pywire/issues/256)
+- Bundled OTel/Sentry extras — [#257](https://github.com/pywire/pywire/issues/257)

--- a/packages/pywire-observability/pyproject.toml
+++ b/packages/pywire-observability/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "pywire-observability"
+version = "0.1.0"
+description = "Request-ID propagation, JSON logging, OpenTelemetry and Sentry recipes for PyWire"
+authors = [
+    { name = "Reece Holmdahl", email = "reece@pywire.dev" },
+]
+requires-python = ">=3.11"
+license = "MIT"
+dependencies = [
+    "pywire>=0.14.2",
+    "starlette>=0.31",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.4",
+    "pytest-asyncio>=0.21",
+    "httpx>=0.25",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/pywire_observability"]

--- a/packages/pywire-observability/pyproject.toml
+++ b/packages/pywire-observability/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 requires-python = ">=3.11"
 license = "MIT"
 dependencies = [
-    "pywire>=0.15.0",
+    "pywire>=0.14.3",
     "starlette>=0.31",
 ]
 

--- a/packages/pywire-observability/pyproject.toml
+++ b/packages/pywire-observability/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 requires-python = ">=3.11"
 license = "MIT"
 dependencies = [
-    "pywire>=0.14.2",
+    "pywire>=0.15.0",
     "starlette>=0.31",
 ]
 

--- a/packages/pywire-observability/scripts/check
+++ b/packages/pywire-observability/scripts/check
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+
+echo "🔍 Running checks for pywire-observability..."
+
+echo "-> ruff format"
+uv run ruff format --check src/ tests/
+
+echo "-> ruff lint"
+uv run ruff check src/ tests/
+
+echo "-> pytest"
+uv run --package pywire-observability pytest tests/

--- a/packages/pywire-observability/scripts/test
+++ b/packages/pywire-observability/scripts/test
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+
+echo "🧪 Running tests for pywire-observability..."
+
+uv run --package pywire-observability --extra dev pytest tests/ "$@"

--- a/packages/pywire-observability/src/pywire_observability/__init__.py
+++ b/packages/pywire-observability/src/pywire_observability/__init__.py
@@ -15,11 +15,17 @@ Public API:
   ``sentry-sdk`` into PyWire's logging + ``@error`` hooks.
 """
 
+from importlib.metadata import PackageNotFoundError, version
+
 from pywire_observability import _compat as _compat  # noqa: F401  (runs floor check)
-from pywire_observability._version import __version__
 from pywire_observability.integration import connect_observability
 from pywire_observability.logging import JSONFormatter, configure_json_logging
 from pywire_observability.middleware import RequestIDMiddleware
+
+try:
+    __version__ = version("pywire-observability")
+except PackageNotFoundError:  # pragma: no cover
+    __version__ = "0.0.0+unknown"
 
 __all__ = [
     "JSONFormatter",

--- a/packages/pywire-observability/src/pywire_observability/__init__.py
+++ b/packages/pywire-observability/src/pywire_observability/__init__.py
@@ -1,0 +1,30 @@
+"""pywire-observability — request-ID propagation, JSON logging, OTel and Sentry recipes.
+
+Public API:
+
+- :func:`connect_observability` — single integration entry point.
+- :class:`RequestIDMiddleware` — pure-ASGI middleware that reads inbound
+  trace headers, generates a fresh ID when absent, and propagates it
+  via ContextVars and ``scope["pywire_request_id"]``.
+- :class:`JSONFormatter` / :func:`configure_json_logging` — JSON log
+  formatter with auto-injected request/connection/event IDs.
+- :mod:`pywire_observability.otel` — small helper that calls
+  ``StarletteInstrumentor.instrument_app`` for users who don't want to
+  learn the underlying API.
+- :mod:`pywire_observability.sentry` — recipe helper for wiring
+  ``sentry-sdk`` into PyWire's logging + ``@error`` hooks.
+"""
+
+from pywire_observability import _compat as _compat  # noqa: F401  (runs floor check)
+from pywire_observability._version import __version__
+from pywire_observability.integration import connect_observability
+from pywire_observability.logging import JSONFormatter, configure_json_logging
+from pywire_observability.middleware import RequestIDMiddleware
+
+__all__ = [
+    "JSONFormatter",
+    "RequestIDMiddleware",
+    "__version__",
+    "configure_json_logging",
+    "connect_observability",
+]

--- a/packages/pywire-observability/src/pywire_observability/_compat.py
+++ b/packages/pywire-observability/src/pywire_observability/_compat.py
@@ -7,7 +7,10 @@ CLAUDE.md "Version Floors" for the bump protocol.
 from importlib.metadata import PackageNotFoundError, version
 
 _FLOORS = {
-    "pywire": "0.14.2",
+    # pywire-observability reads the observability ContextVars and
+    # BasePage.request_id attribute that ship in pywire 0.15.0
+    # (the same release that introduces the observability seams).
+    "pywire": "0.15.0",
 }
 
 

--- a/packages/pywire-observability/src/pywire_observability/_compat.py
+++ b/packages/pywire-observability/src/pywire_observability/_compat.py
@@ -1,0 +1,35 @@
+"""Runtime version-floor checks for upstream packages.
+
+See packages/pywire/src/pywire/_compat.py for the rationale and
+CLAUDE.md "Version Floors" for the bump protocol.
+"""
+
+from importlib.metadata import PackageNotFoundError, version
+
+_FLOORS = {
+    "pywire": "0.14.2",
+}
+
+
+def _parse(v: str) -> tuple[int, ...]:
+    out: list[int] = []
+    for chunk in v.split("."):
+        digits = ""
+        for ch in chunk:
+            if not ch.isdigit():
+                break
+            digits += ch
+        out.append(int(digits) if digits else 0)
+    return tuple(out)
+
+
+for _pkg, _min in _FLOORS.items():
+    try:
+        _installed = version(_pkg)
+    except PackageNotFoundError:
+        continue
+    if _parse(_installed) < _parse(_min):
+        raise ImportError(
+            f"pywire-observability requires {_pkg}>={_min} but found {_installed}. "
+            f"Run: pip install -U '{_pkg}>={_min}'"
+        )

--- a/packages/pywire-observability/src/pywire_observability/_compat.py
+++ b/packages/pywire-observability/src/pywire_observability/_compat.py
@@ -8,9 +8,10 @@ from importlib.metadata import PackageNotFoundError, version
 
 _FLOORS = {
     # pywire-observability reads the observability ContextVars and
-    # BasePage.request_id attribute that ship in pywire 0.15.0
-    # (the same release that introduces the observability seams).
-    "pywire": "0.15.0",
+    # BasePage.request_id, added in the same monorepo release wave
+    # as pywire-observability 0.1.0. Bump in lockstep when release-please
+    # cuts the next pywire after the observability seams land.
+    "pywire": "0.14.3",
 }
 
 

--- a/packages/pywire-observability/src/pywire_observability/integration.py
+++ b/packages/pywire-observability/src/pywire_observability/integration.py
@@ -5,11 +5,21 @@ swaps the root logger's formatter for :class:`JSONFormatter`. Errors
 from the framework's WS / HTTP-500 paths flow through the standard
 ``pywire.*`` loggers (fixed in core), so installing the JSON formatter
 also captures those.
+
+Multi-worker note: uvicorn spawns workers with a fresh interpreter, so
+JSON logging configured in the parent process is NOT inherited. The
+right place to call this is inside your ``main.py`` (or wherever
+``PyWire(...)`` is constructed) so each worker re-runs the
+configuration on import. The ``pywire run --log-format=json`` CLI
+flag sets ``PYWIRE_LOG_FORMAT=json`` in the environment so workers
+that call ``connect_observability(..., json_logging=None)`` (the
+default) will pick it up.
 """
 
 from __future__ import annotations
 
 import logging
+import os
 from typing import Any, Optional, Sequence
 
 from pywire_observability.logging import configure_json_logging
@@ -22,7 +32,7 @@ def connect_observability(
     request_id: bool = True,
     request_id_header: str = "x-request-id",
     inbound_headers: Optional[Sequence[str]] = None,
-    json_logging: bool = False,
+    json_logging: Optional[bool] = None,
     log_level: int = logging.INFO,
     static_log_fields: Optional[dict[str, Any]] = None,
 ) -> None:
@@ -36,12 +46,14 @@ def connect_observability(
         inbound_headers: Override the inbound header priority list.
             Defaults to ``traceparent``, ``x-request-id``,
             ``x-correlation-id``.
-        json_logging: Replace the root logger's handlers with a single
-            :class:`JSONFormatter` handler. Idempotent. Off by default;
-            also activatable via ``PYWIRE_LOG_FORMAT=json`` env or
-            ``pywire run --log-format=json`` CLI flag.
-        log_level: Level applied to the root logger when JSON logging is
-            enabled.
+        json_logging: Tri-state. ``True`` always installs the JSON
+            handler. ``False`` always skips it. ``None`` (default)
+            reads ``PYWIRE_LOG_FORMAT`` from the environment —
+            ``json`` enables, anything else disables. The env-var
+            path is what makes ``pywire run --log-format=json``
+            propagate to forked workers.
+        log_level: Level applied to the root logger when JSON logging
+            is enabled.
         static_log_fields: Extra keys merged into every JSON record
             (e.g. ``{\"service\": \"my-app\", \"env\": \"prod\"}``).
     """
@@ -51,5 +63,7 @@ def connect_observability(
             kwargs["inbound_headers"] = tuple(inbound_headers)
         app.add_middleware(RequestIDMiddleware, **kwargs)
 
+    if json_logging is None:
+        json_logging = os.environ.get("PYWIRE_LOG_FORMAT", "").lower() == "json"
     if json_logging:
         configure_json_logging(level=log_level, static_fields=static_log_fields)

--- a/packages/pywire-observability/src/pywire_observability/integration.py
+++ b/packages/pywire-observability/src/pywire_observability/integration.py
@@ -1,0 +1,55 @@
+"""Single integration entry point — ``connect_observability(app, ...)``.
+
+Wires :class:`RequestIDMiddleware` onto a PyWire app and (optionally)
+swaps the root logger's formatter for :class:`JSONFormatter`. Errors
+from the framework's WS / HTTP-500 paths flow through the standard
+``pywire.*`` loggers (fixed in core), so installing the JSON formatter
+also captures those.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional, Sequence
+
+from pywire_observability.logging import configure_json_logging
+from pywire_observability.middleware import RequestIDMiddleware
+
+
+def connect_observability(
+    app: Any,
+    *,
+    request_id: bool = True,
+    request_id_header: str = "x-request-id",
+    inbound_headers: Optional[Sequence[str]] = None,
+    json_logging: bool = False,
+    log_level: int = logging.INFO,
+    static_log_fields: Optional[dict[str, Any]] = None,
+) -> None:
+    """Attach observability middleware to a PyWire app.
+
+    Args:
+        app: The :class:`pywire.PyWire` instance.
+        request_id: Install :class:`RequestIDMiddleware`. Default on.
+        request_id_header: Outbound header name to echo the id under
+            (case-insensitive). Default ``X-Request-ID``.
+        inbound_headers: Override the inbound header priority list.
+            Defaults to ``traceparent``, ``x-request-id``,
+            ``x-correlation-id``.
+        json_logging: Replace the root logger's handlers with a single
+            :class:`JSONFormatter` handler. Idempotent. Off by default;
+            also activatable via ``PYWIRE_LOG_FORMAT=json`` env or
+            ``pywire run --log-format=json`` CLI flag.
+        log_level: Level applied to the root logger when JSON logging is
+            enabled.
+        static_log_fields: Extra keys merged into every JSON record
+            (e.g. ``{\"service\": \"my-app\", \"env\": \"prod\"}``).
+    """
+    if request_id:
+        kwargs: dict[str, Any] = {"header_name": request_id_header}
+        if inbound_headers is not None:
+            kwargs["inbound_headers"] = tuple(inbound_headers)
+        app.add_middleware(RequestIDMiddleware, **kwargs)
+
+    if json_logging:
+        configure_json_logging(level=log_level, static_fields=static_log_fields)

--- a/packages/pywire-observability/src/pywire_observability/logging.py
+++ b/packages/pywire-observability/src/pywire_observability/logging.py
@@ -1,0 +1,199 @@
+"""JSON log formatter for PyWire apps.
+
+A single-record-per-line JSON formatter that pulls request-scoped
+context (request_id, connection_id, event_id) from the framework's
+ContextVars when present. Compatible with Datadog, ELK, Loki,
+CloudWatch, Cloud Logging, and Azure Monitor — all of which auto-parse
+JSON-per-line stdout.
+
+Activate via :func:`configure_json_logging` or the CLI flag
+``pywire run --log-format=json`` / ``pywire dev --log-format=json``.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import logging
+import sys
+import traceback
+from typing import Any, Optional
+
+
+# These keys come from logging.LogRecord and are always present;
+# excluding them from the "extra fields" pass keeps the output schema
+# clean. ``getMessage`` covers ``msg`` + ``args``.
+_RESERVED_RECORD_ATTRS = frozenset(
+    {
+        "args",
+        "asctime",
+        "created",
+        "exc_info",
+        "exc_text",
+        "filename",
+        "funcName",
+        "levelname",
+        "levelno",
+        "lineno",
+        "message",
+        "module",
+        "msecs",
+        "msg",
+        "name",
+        "pathname",
+        "process",
+        "processName",
+        "relativeCreated",
+        "stack_info",
+        "thread",
+        "threadName",
+        "taskName",
+    }
+)
+
+
+class JSONFormatter(logging.Formatter):
+    """Emit each log record as a single line of JSON.
+
+    Output schema::
+
+        {
+          "timestamp": "2026-05-05T14:32:01.234567+00:00",
+          "level": "INFO",
+          "logger": "pywire.runtime.app",
+          "message": "Page rendered",
+          "request_id": "...",         # when set
+          "connection_id": "...",       # when set on WS scopes
+          "event_id": "...",            # when set inside an event handler
+          "exception": "Traceback...",  # when exc_info is present
+          "extra_user_field": "..."     # arbitrary keys from logger.info(..., extra={...})
+        }
+    """
+
+    def __init__(
+        self,
+        *,
+        include_context: bool = True,
+        static_fields: Optional[dict[str, Any]] = None,
+    ) -> None:
+        super().__init__()
+        self._include_context = include_context
+        self._static_fields = dict(static_fields or {})
+
+    def format(self, record: logging.LogRecord) -> str:
+        payload: dict[str, Any] = {
+            "timestamp": _format_timestamp(record),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+
+        if self._static_fields:
+            payload.update(self._static_fields)
+
+        if self._include_context:
+            ctx = _read_context()
+            if ctx:
+                payload.update(ctx)
+
+        for key, value in record.__dict__.items():
+            if key in _RESERVED_RECORD_ATTRS or key.startswith("_"):
+                continue
+            if key in payload:
+                continue
+            payload[key] = _coerce(value)
+
+        if record.exc_info:
+            payload["exception"] = "".join(traceback.format_exception(*record.exc_info))
+        elif record.exc_text:
+            payload["exception"] = record.exc_text
+        if record.stack_info:
+            payload["stack"] = record.stack_info
+
+        try:
+            return json.dumps(payload, default=_coerce, separators=(",", ":"))
+        except (TypeError, ValueError):
+            # Fall back to a degraded record so a bad ``extra=`` dict
+            # never breaks logging itself.
+            return json.dumps(
+                {
+                    "timestamp": payload["timestamp"],
+                    "level": payload["level"],
+                    "logger": payload["logger"],
+                    "message": payload["message"],
+                    "_format_error": "non-serialisable extra fields dropped",
+                },
+                separators=(",", ":"),
+            )
+
+
+def _format_timestamp(record: logging.LogRecord) -> str:
+    return _dt.datetime.fromtimestamp(record.created, tz=_dt.timezone.utc).isoformat()
+
+
+def _read_context() -> dict[str, str]:
+    """Return whichever of request_id/connection_id/event_id are set.
+
+    The ContextVars live in :mod:`pywire.runtime.observability`. Fail
+    silently if pywire isn't importable or the module hasn't shipped
+    yet — the formatter still works as a generic JSON logger.
+    """
+    try:
+        from pywire.runtime.observability import (
+            connection_id_ctx,
+            event_id_ctx,
+            request_id_ctx,
+        )
+    except ImportError:
+        return {}
+
+    out: dict[str, str] = {}
+    rid = request_id_ctx.get()
+    if rid:
+        out["request_id"] = rid
+    cid = connection_id_ctx.get()
+    if cid:
+        out["connection_id"] = cid
+    eid = event_id_ctx.get()
+    if eid:
+        out["event_id"] = eid
+    return out
+
+
+def _coerce(value: Any) -> Any:
+    """Best-effort conversion of non-JSON-native values to strings."""
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    if isinstance(value, (list, tuple)):
+        return [_coerce(v) for v in value]
+    if isinstance(value, dict):
+        return {str(k): _coerce(v) for k, v in value.items()}
+    return repr(value)
+
+
+def configure_json_logging(
+    *,
+    level: int = logging.INFO,
+    stream: Any = None,
+    static_fields: Optional[dict[str, Any]] = None,
+) -> logging.Handler:
+    """Install :class:`JSONFormatter` on the root logger.
+
+    Removes any existing handlers and replaces them with a single
+    StreamHandler writing to stderr (default) so log line ordering is
+    deterministic. Returns the installed handler so callers can adjust
+    afterwards.
+
+    Idempotent — calling twice replaces the previous handler.
+    """
+    handler = logging.StreamHandler(stream or sys.stderr)
+    handler.setFormatter(JSONFormatter(static_fields=static_fields))
+    handler.setLevel(level)
+
+    root = logging.getLogger()
+    for existing in list(root.handlers):
+        root.removeHandler(existing)
+    root.addHandler(handler)
+    root.setLevel(level)
+
+    return handler

--- a/packages/pywire-observability/src/pywire_observability/logging.py
+++ b/packages/pywire-observability/src/pywire_observability/logging.py
@@ -112,9 +112,9 @@ class JSONFormatter(logging.Formatter):
 
         try:
             return json.dumps(payload, default=_coerce, separators=(",", ":"))
-        except (TypeError, ValueError):
+        except (TypeError, ValueError, RecursionError):
             # Fall back to a degraded record so a bad ``extra=`` dict
-            # never breaks logging itself.
+            # (cycles, exotic types, etc.) never breaks logging itself.
             return json.dumps(
                 {
                     "timestamp": payload["timestamp"],
@@ -160,15 +160,29 @@ def _read_context() -> dict[str, str]:
     return out
 
 
-def _coerce(value: Any) -> Any:
-    """Best-effort conversion of non-JSON-native values to strings."""
+_MAX_COERCE_DEPTH = 8
+
+
+def _coerce(value: Any, _depth: int = 0) -> Any:
+    """Best-effort conversion of non-JSON-native values to strings.
+
+    Recurses into containers up to :data:`_MAX_COERCE_DEPTH` to keep
+    cyclic ``extra=`` dicts from blowing the stack. Beyond the depth
+    limit (or for unknown types) the value is replaced with its
+    ``repr`` so the record always serialises.
+    """
     if isinstance(value, (str, int, float, bool)) or value is None:
         return value
+    if _depth >= _MAX_COERCE_DEPTH:
+        return repr(value)
     if isinstance(value, (list, tuple)):
-        return [_coerce(v) for v in value]
+        return [_coerce(v, _depth + 1) for v in value]
     if isinstance(value, dict):
-        return {str(k): _coerce(v) for k, v in value.items()}
+        return {str(k): _coerce(v, _depth + 1) for k, v in value.items()}
     return repr(value)
+
+
+_PYWIRE_JSON_HANDLER_MARKER = "_pywire_json_handler"
 
 
 def configure_json_logging(
@@ -179,18 +193,35 @@ def configure_json_logging(
 ) -> logging.Handler:
     """Install :class:`JSONFormatter` on the root logger.
 
-    Removes any existing handlers and replaces them with a single
+    Removes any existing root handlers and replaces them with a single
     StreamHandler writing to stderr (default) so log line ordering is
-    deterministic. Returns the installed handler so callers can adjust
-    afterwards.
+    deterministic across uvicorn workers. **Destroys** any prior root
+    handlers — call this *before* installing app-specific handlers, or
+    skip JSON mode and configure logging yourself. A warning is emitted
+    when non-pywire handlers are removed so the destruction isn't silent.
 
-    Idempotent — calling twice replaces the previous handler.
+    Idempotent — calling twice replaces the previous JSON handler
+    without re-warning.
     """
+    import warnings
+
     handler = logging.StreamHandler(stream or sys.stderr)
     handler.setFormatter(JSONFormatter(static_fields=static_fields))
     handler.setLevel(level)
+    setattr(handler, _PYWIRE_JSON_HANDLER_MARKER, True)
 
     root = logging.getLogger()
+    foreign_handlers = [
+        h for h in root.handlers if not getattr(h, _PYWIRE_JSON_HANDLER_MARKER, False)
+    ]
+    if foreign_handlers:
+        warnings.warn(
+            f"configure_json_logging removed {len(foreign_handlers)} "
+            "existing root logger handler(s). Call configure_json_logging "
+            "before installing your own handlers, or set --log-format=text "
+            "and configure logging yourself.",
+            stacklevel=2,
+        )
     for existing in list(root.handlers):
         root.removeHandler(existing)
     root.addHandler(handler)

--- a/packages/pywire-observability/src/pywire_observability/middleware.py
+++ b/packages/pywire-observability/src/pywire_observability/middleware.py
@@ -80,14 +80,12 @@ class RequestIDMiddleware:
 
     def _extract_or_generate(self, scope: dict) -> str:
         for name, value in scope.get("headers", []):
-            try:
-                lower = name.lower()
-            except AttributeError:
-                continue
-            if isinstance(lower, bytes):
-                lower_str = lower.decode("latin-1")
+            # ASGI guarantees bytes for header names, but accept str
+            # defensively for tests / unusual middleware that ships str.
+            if isinstance(name, bytes):
+                lower_str = name.decode("latin-1").lower()
             else:
-                lower_str = lower
+                lower_str = name.lower()
             if lower_str not in self.inbound_headers:
                 continue
             decoded = self._decode_header_value(value)
@@ -125,7 +123,7 @@ class RequestIDMiddleware:
             if message["type"] == "http.response.start":
                 hdrs = list(message.get("headers", []))
                 if not any(
-                    (n.lower() if isinstance(n, bytes) else n.encode().lower())
+                    (n.lower() if isinstance(n, bytes) else n.encode("latin-1").lower())
                     == echo_name
                     for n, _ in hdrs
                 ):
@@ -136,13 +134,24 @@ class RequestIDMiddleware:
         return patched
 
 
+_INVALID_TRACE_ID = "0" * 32
+
+
 def _trace_id_from_traceparent(value: str) -> Optional[str]:
     """Pull the 32-hex trace_id from a W3C traceparent header.
 
     Returns ``None`` for malformed values so callers fall through to
     the next header in the priority list (or the UUID4 fallback).
+
+    The all-zeros trace_id is reserved by the W3C Trace Context spec
+    (§2.2.3) as "invalid"; treating it as a real id would collapse
+    every request from a misconfigured upstream into a single
+    correlation bucket. We reject it explicitly.
     """
     match = _TRACEPARENT_RE.match(value.strip())
     if match is None:
         return None
-    return match.group(1)
+    trace_id = match.group(1)
+    if trace_id == _INVALID_TRACE_ID:
+        return None
+    return trace_id

--- a/packages/pywire-observability/src/pywire_observability/middleware.py
+++ b/packages/pywire-observability/src/pywire_observability/middleware.py
@@ -1,0 +1,148 @@
+"""Pure-ASGI request-ID propagation middleware.
+
+For every HTTP request and WebSocket connection, the middleware:
+
+1. Reads inbound trace headers in priority order:
+   ``traceparent`` (W3C) → ``x-request-id`` → ``x-correlation-id``.
+2. Generates a fresh ID when none is present (UUID4 hex by default).
+3. Writes it to ``scope["pywire_request_id"]`` so :class:`BasePage`
+   surfaces it as ``self.request_id`` and other middleware can read it.
+4. Sets :data:`pywire.runtime.observability.request_id_ctx` for the
+   duration of the request — log records emitted from anywhere in the
+   request path (handlers, background tasks spawned during the request,
+   render callbacks) automatically carry the id when the JSON formatter
+   is active.
+5. Echoes the id back as ``X-Request-ID`` on HTTP responses so clients
+   and downstream services can correlate.
+
+Generated IDs are UUID4 hex by default. When ``traceparent`` is present,
+the W3C trace-id portion is preserved instead so OTel-aware backends
+(Datadog, Honeycomb, Tempo, Jaeger) link logs to the originating trace
+without bespoke configuration.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from typing import Any, Awaitable, Callable, Optional, Sequence
+
+# W3C trace-context: ``00-<32 hex trace_id>-<16 hex span_id>-<2 hex flags>``
+_TRACEPARENT_RE = re.compile(r"^[0-9a-f]{2}-([0-9a-f]{32})-[0-9a-f]{16}-[0-9a-f]{2}$")
+
+
+class RequestIDMiddleware:
+    """Read or mint a request id and propagate it through the request."""
+
+    def __init__(
+        self,
+        app: Any,
+        *,
+        header_name: str = "x-request-id",
+        inbound_headers: Sequence[str] = (
+            "traceparent",
+            "x-request-id",
+            "x-correlation-id",
+        ),
+        echo_response_header: bool = True,
+    ) -> None:
+        self.app = app
+        self.header_name = header_name.lower()
+        self.inbound_headers = tuple(h.lower() for h in inbound_headers)
+        self.echo_response_header = echo_response_header
+
+    async def __call__(
+        self,
+        scope: dict,
+        receive: Callable[[], Awaitable[dict]],
+        send: Callable[[dict], Awaitable[None]],
+    ) -> None:
+        if scope["type"] not in ("http", "websocket"):
+            await self.app(scope, receive, send)
+            return
+
+        request_id = self._extract_or_generate(scope)
+        scope["pywire_request_id"] = request_id
+
+        # Set the ContextVar before dispatching so log records emitted
+        # synchronously inside the downstream handler see the id. The
+        # ContextVar lives in pywire core (pure stdlib).
+        from pywire.runtime.observability import request_id_ctx
+
+        token = request_id_ctx.set(request_id)
+        try:
+            if scope["type"] == "http" and self.echo_response_header:
+                await self.app(scope, receive, self._wrap_send(send, request_id))
+            else:
+                await self.app(scope, receive, send)
+        finally:
+            request_id_ctx.reset(token)
+
+    def _extract_or_generate(self, scope: dict) -> str:
+        for name, value in scope.get("headers", []):
+            try:
+                lower = name.lower()
+            except AttributeError:
+                continue
+            if isinstance(lower, bytes):
+                lower_str = lower.decode("latin-1")
+            else:
+                lower_str = lower
+            if lower_str not in self.inbound_headers:
+                continue
+            decoded = self._decode_header_value(value)
+            if not decoded:
+                continue
+            extracted = (
+                _trace_id_from_traceparent(decoded)
+                if lower_str == "traceparent"
+                else decoded
+            )
+            if extracted:
+                return extracted
+        return uuid.uuid4().hex
+
+    @staticmethod
+    def _decode_header_value(value: Any) -> Optional[str]:
+        if isinstance(value, bytes):
+            try:
+                return value.decode("latin-1")
+            except UnicodeDecodeError:
+                return None
+        if isinstance(value, str):
+            return value
+        return None
+
+    def _wrap_send(
+        self,
+        send: Callable[[dict], Awaitable[None]],
+        request_id: str,
+    ) -> Callable[[dict], Awaitable[None]]:
+        echo_name = self.header_name.encode("latin-1")
+        echo_value = request_id.encode("latin-1")
+
+        async def patched(message: dict) -> None:
+            if message["type"] == "http.response.start":
+                hdrs = list(message.get("headers", []))
+                if not any(
+                    (n.lower() if isinstance(n, bytes) else n.encode().lower())
+                    == echo_name
+                    for n, _ in hdrs
+                ):
+                    hdrs.append((echo_name, echo_value))
+                message = {**message, "headers": hdrs}
+            await send(message)
+
+        return patched
+
+
+def _trace_id_from_traceparent(value: str) -> Optional[str]:
+    """Pull the 32-hex trace_id from a W3C traceparent header.
+
+    Returns ``None`` for malformed values so callers fall through to
+    the next header in the priority list (or the UUID4 fallback).
+    """
+    match = _TRACEPARENT_RE.match(value.strip())
+    if match is None:
+        return None
+    return match.group(1)

--- a/packages/pywire-observability/src/pywire_observability/otel.py
+++ b/packages/pywire-observability/src/pywire_observability/otel.py
@@ -1,0 +1,99 @@
+"""OpenTelemetry instrumentation recipe.
+
+PyWire does not bundle the OTel SDK. Install the right packages for
+your destination::
+
+    pip install opentelemetry-api opentelemetry-sdk \\
+                opentelemetry-instrumentation-starlette \\
+                opentelemetry-exporter-otlp
+
+Then::
+
+    from pywire import PyWire
+    from pywire_observability.otel import instrument
+
+    app = PyWire(...)
+    instrument(app)
+
+This wires the standard Starlette ASGI instrumentation onto PyWire's
+inner Starlette app. HTTP requests and WebSocket upgrade handshakes
+are auto-spanned. Per-WS-event spans are NOT yet covered (see
+https://github.com/pywire/pywire/issues/254).
+
+Internal ASGI replay requests (``X-PyWire-Internal: relocate``) are
+filtered out by the default ``server_request_hook`` so the trace tree
+isn't cluttered with framework-internal duplicates of the user's
+request span.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Optional
+
+
+def instrument(
+    app: Any,
+    *,
+    server_request_hook: Optional[Callable[[Any, dict], None]] = None,
+    client_request_hook: Optional[Callable[[Any, dict], None]] = None,
+    excluded_urls: Optional[str] = None,
+) -> None:
+    """Apply Starlette OTel instrumentation to a PyWire app.
+
+    Args:
+        app: The :class:`pywire.PyWire` instance.
+        server_request_hook: Custom hook that runs on every incoming
+            request span. If omitted, a default hook drops the span
+            for internal ASGI replays so they don't double-count.
+        client_request_hook: Optional hook for outgoing request spans
+            (rarely needed for PyWire — most apps don't make outbound
+            calls from the request path).
+        excluded_urls: Comma-separated URL substrings to skip. Useful
+            for ``/_pywire/static`` and health endpoints.
+
+    Raises ``ImportError`` with the install command when the
+    OpenTelemetry packages aren't installed.
+    """
+    try:
+        from opentelemetry.instrumentation.starlette import StarletteInstrumentor
+    except ImportError as exc:  # pragma: no cover
+        raise ImportError(
+            "pywire_observability.otel.instrument requires the OpenTelemetry "
+            "instrumentation packages. Install with:\n"
+            "  pip install opentelemetry-api opentelemetry-sdk "
+            "opentelemetry-instrumentation-starlette"
+        ) from exc
+
+    hook = server_request_hook or _default_server_request_hook
+
+    inner = getattr(app, "app", app)
+    StarletteInstrumentor.instrument_app(
+        inner,
+        server_request_hook=hook,
+        client_request_hook=client_request_hook,
+        excluded_urls=excluded_urls,
+    )
+
+
+def _default_server_request_hook(span: Any, scope: dict) -> None:
+    """Drop spans for PyWire's internal ASGI replays.
+
+    The framework re-dispatches requests through its own ASGI app for
+    SPA navigation (``X-PyWire-Internal: relocate``). Letting OTel
+    span those produces a duplicate of the user-visible request span
+    in trace tools.
+    """
+    if span is None:
+        return
+    headers = scope.get("headers") or []
+    for name, value in headers:
+        try:
+            n = name.lower() if isinstance(name, bytes) else name.encode().lower()
+        except (AttributeError, UnicodeError):
+            continue
+        if n == b"x-pywire-internal":
+            try:
+                span.set_attribute("pywire.internal_replay", True)
+            except Exception:
+                pass
+            return

--- a/packages/pywire-observability/src/pywire_observability/sentry.py
+++ b/packages/pywire-observability/src/pywire_observability/sentry.py
@@ -1,0 +1,97 @@
+"""Sentry integration recipe.
+
+PyWire does not bundle ``sentry-sdk``. Install it yourself::
+
+    pip install 'sentry-sdk[starlette]'
+
+Then call :func:`init` once at startup::
+
+    from pywire_observability.sentry import init as init_sentry
+
+    init_sentry(dsn=os.environ["SENTRY_DSN"], environment=\"prod\")
+
+This wires:
+
+- Sentry's ``LoggingIntegration`` capturing all ``logger.exception(...)``
+  calls — including the WS / HTTP-500 fixes pywire-observability ships.
+- Sentry's ``StarletteIntegration`` for HTTP request context.
+- Tags every captured event with ``pywire_request_id``,
+  ``pywire_connection_id``, and ``pywire_event_id`` when present so
+  Sentry issues are searchable by the same IDs that appear in JSON logs.
+
+For more advanced setups (custom transports, before-send filters,
+performance sampling), call ``sentry_sdk.init(...)`` directly with
+your own kwargs.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+
+def init(
+    *,
+    dsn: str,
+    environment: Optional[str] = None,
+    release: Optional[str] = None,
+    traces_sample_rate: float = 0.0,
+    sample_rate: float = 1.0,
+    **extra_kwargs: Any,
+) -> None:
+    """Initialize ``sentry-sdk`` with PyWire-aware defaults.
+
+    Args mirror the most common ``sentry_sdk.init`` kwargs. Pass any
+    additional ``sentry_sdk.init`` kwargs through ``extra_kwargs``.
+    """
+    try:
+        import sentry_sdk
+        from sentry_sdk.integrations.logging import LoggingIntegration
+        from sentry_sdk.integrations.starlette import StarletteIntegration
+    except ImportError as exc:  # pragma: no cover
+        raise ImportError(
+            "pywire_observability.sentry.init requires sentry-sdk. "
+            "Install with: pip install 'sentry-sdk[starlette]'"
+        ) from exc
+
+    sentry_sdk.init(
+        dsn=dsn,
+        environment=environment,
+        release=release,
+        traces_sample_rate=traces_sample_rate,
+        sample_rate=sample_rate,
+        integrations=[
+            LoggingIntegration(),
+            StarletteIntegration(),
+        ],
+        before_send=_attach_pywire_tags,
+        **extra_kwargs,
+    )
+
+
+def _attach_pywire_tags(event: dict, hint: dict) -> dict:
+    """Tag every Sentry event with current PyWire request/connection/event IDs.
+
+    Reads from :mod:`pywire.runtime.observability` ContextVars. When
+    the framework hasn't set them (e.g. background work outside any
+    request), the tags are simply absent.
+    """
+    try:
+        from pywire.runtime.observability import (
+            connection_id_ctx,
+            event_id_ctx,
+            request_id_ctx,
+        )
+    except ImportError:
+        return event
+
+    tags = event.setdefault("tags", {})
+    rid = request_id_ctx.get()
+    if rid:
+        tags["pywire_request_id"] = rid
+    cid = connection_id_ctx.get()
+    if cid:
+        tags["pywire_connection_id"] = cid
+    eid = event_id_ctx.get()
+    if eid:
+        tags["pywire_event_id"] = eid
+    return event

--- a/packages/pywire-observability/tests/test_integration.py
+++ b/packages/pywire-observability/tests/test_integration.py
@@ -54,6 +54,50 @@ def test_json_logging_off_by_default() -> None:
     assert root.handlers == handlers_before
 
 
+def test_json_logging_env_var_activates_when_default_none(
+    monkeypatch,
+) -> None:
+    """connect_observability(json_logging=None) reads PYWIRE_LOG_FORMAT
+    so workers forked by uvicorn pick up the parent's --log-format=json
+    setting via env-var inheritance."""
+    monkeypatch.setenv("PYWIRE_LOG_FORMAT", "json")
+    app = _StubApp()
+    root = logging.getLogger()
+    saved = list(root.handlers)
+    try:
+        connect_observability(app)
+        # JSON handler installed because env var said so.
+        from pywire_observability.logging import _PYWIRE_JSON_HANDLER_MARKER
+
+        assert any(
+            getattr(h, _PYWIRE_JSON_HANDLER_MARKER, False) for h in root.handlers
+        )
+    finally:
+        for h in list(root.handlers):
+            root.removeHandler(h)
+        for h in saved:
+            root.addHandler(h)
+
+
+def test_json_logging_explicit_false_overrides_env(monkeypatch) -> None:
+    monkeypatch.setenv("PYWIRE_LOG_FORMAT", "json")
+    app = _StubApp()
+    root = logging.getLogger()
+    saved = list(root.handlers)
+    try:
+        connect_observability(app, json_logging=False)
+        from pywire_observability.logging import _PYWIRE_JSON_HANDLER_MARKER
+
+        assert not any(
+            getattr(h, _PYWIRE_JSON_HANDLER_MARKER, False) for h in root.handlers
+        )
+    finally:
+        for h in list(root.handlers):
+            root.removeHandler(h)
+        for h in saved:
+            root.addHandler(h)
+
+
 def test_json_logging_when_enabled() -> None:
     """connect_observability(json_logging=True) installs the JSON handler."""
     import io

--- a/packages/pywire-observability/tests/test_integration.py
+++ b/packages/pywire-observability/tests/test_integration.py
@@ -1,0 +1,82 @@
+"""Tests for ``connect_observability``."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from pywire_observability import RequestIDMiddleware, connect_observability
+
+
+class _StubApp:
+    def __init__(self) -> None:
+        self.middleware: list[tuple[type, dict]] = []
+
+    def add_middleware(self, cls: type, **kwargs: Any) -> None:
+        self.middleware.append((cls, kwargs))
+
+
+def _classes(app: _StubApp) -> list[type]:
+    return [cls for cls, _ in app.middleware]
+
+
+def test_default_install_adds_request_id_middleware() -> None:
+    app = _StubApp()
+    connect_observability(app)
+    assert RequestIDMiddleware in _classes(app)
+
+
+def test_request_id_disabled_skips_middleware() -> None:
+    app = _StubApp()
+    connect_observability(app, request_id=False)
+    assert RequestIDMiddleware not in _classes(app)
+
+
+def test_custom_inbound_headers_passed_through() -> None:
+    app = _StubApp()
+    connect_observability(app, inbound_headers=("x-custom-trace",))
+    kwargs = next(kw for cls, kw in app.middleware if cls is RequestIDMiddleware)
+    assert kwargs["inbound_headers"] == ("x-custom-trace",)
+
+
+def test_custom_response_header_name() -> None:
+    app = _StubApp()
+    connect_observability(app, request_id_header="x-trace-id")
+    kwargs = next(kw for cls, kw in app.middleware if cls is RequestIDMiddleware)
+    assert kwargs["header_name"] == "x-trace-id"
+
+
+def test_json_logging_off_by_default() -> None:
+    app = _StubApp()
+    root = logging.getLogger()
+    handlers_before = list(root.handlers)
+    connect_observability(app)
+    assert root.handlers == handlers_before
+
+
+def test_json_logging_when_enabled() -> None:
+    """connect_observability(json_logging=True) installs the JSON handler."""
+    import io
+    import json as _json
+
+    app = _StubApp()
+    stream = io.StringIO()
+
+    # configure_json_logging respects a custom stream — but
+    # connect_observability doesn't expose that yet; we exercise the
+    # plumbing via the public path (root logger) and check effects.
+    root = logging.getLogger()
+    saved = list(root.handlers)
+    try:
+        connect_observability(app, json_logging=True)
+        # Replace the installed handler's stream so we can capture.
+        root.handlers[0].stream = stream  # type: ignore[attr-defined]
+        root.info("after-config")
+        line = stream.getvalue().strip().splitlines()[-1]
+        payload = _json.loads(line)
+        assert payload["message"] == "after-config"
+    finally:
+        for h in list(root.handlers):
+            root.removeHandler(h)
+        for h in saved:
+            root.addHandler(h)

--- a/packages/pywire-observability/tests/test_logging.py
+++ b/packages/pywire-observability/tests/test_logging.py
@@ -165,3 +165,64 @@ def test_configure_json_logging_idempotent() -> None:
 def test_levels_serialised(level_no: int, level_name: str) -> None:
     out = _format_record(level=level_no)
     assert out["level"] == level_name
+
+
+def test_cyclic_extra_does_not_crash_logging() -> None:
+    """A cyclic extra= dict would recurse forever in _coerce without
+    the depth guard. Confirm the formatter degrades cleanly to repr
+    instead of raising RecursionError."""
+    cycle: dict = {}
+    cycle["self"] = cycle
+    out = _format_record(weird=cycle)
+    # Formatter must produce SOMETHING — either a depth-limited
+    # representation under the field, or the fallback degraded record.
+    # Either way, it didn't raise.
+    assert "level" in out
+
+
+def test_configure_json_logging_warns_on_foreign_handlers() -> None:
+    import io
+    import warnings
+
+    root = logging.getLogger()
+    saved = list(root.handlers)
+    foreign = logging.StreamHandler(io.StringIO())
+    root.addHandler(foreign)
+    try:
+        with warnings.catch_warnings(record=True) as recorded:
+            warnings.simplefilter("always")
+            handler = configure_json_logging(stream=io.StringIO())
+        assert any(
+            "removed" in str(w.message) and "handler" in str(w.message)
+            for w in recorded
+        )
+    finally:
+        for h in list(root.handlers):
+            root.removeHandler(h)
+        for h in saved:
+            root.addHandler(h)
+
+
+def test_configure_json_logging_does_not_warn_on_replace_self() -> None:
+    """Re-configuring after a previous configure_json_logging call must
+    not warn — the marker on our own handler tells us we're replacing
+    a pywire-installed handler, not a foreign one."""
+    import io
+    import warnings
+
+    root = logging.getLogger()
+    saved = list(root.handlers)
+    try:
+        # Clean slate.
+        for h in list(root.handlers):
+            root.removeHandler(h)
+        configure_json_logging(stream=io.StringIO())
+        with warnings.catch_warnings(record=True) as recorded:
+            warnings.simplefilter("always")
+            configure_json_logging(stream=io.StringIO())
+        assert not any("removed" in str(w.message) for w in recorded)
+    finally:
+        for h in list(root.handlers):
+            root.removeHandler(h)
+        for h in saved:
+            root.addHandler(h)

--- a/packages/pywire-observability/tests/test_logging.py
+++ b/packages/pywire-observability/tests/test_logging.py
@@ -191,7 +191,7 @@ def test_configure_json_logging_warns_on_foreign_handlers() -> None:
     try:
         with warnings.catch_warnings(record=True) as recorded:
             warnings.simplefilter("always")
-            handler = configure_json_logging(stream=io.StringIO())
+            configure_json_logging(stream=io.StringIO())
         assert any(
             "removed" in str(w.message) and "handler" in str(w.message)
             for w in recorded

--- a/packages/pywire-observability/tests/test_logging.py
+++ b/packages/pywire-observability/tests/test_logging.py
@@ -1,0 +1,167 @@
+"""Tests for the JSON log formatter."""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+
+import pytest
+
+from pywire_observability.logging import JSONFormatter, configure_json_logging
+
+
+def _format_record(**record_kwargs) -> dict:
+    formatter = JSONFormatter()
+    record = logging.LogRecord(
+        name=record_kwargs.pop("name", "test"),
+        level=record_kwargs.pop("level", logging.INFO),
+        pathname=record_kwargs.pop("pathname", "/tmp/x.py"),
+        lineno=record_kwargs.pop("lineno", 1),
+        msg=record_kwargs.pop("msg", "hello"),
+        args=record_kwargs.pop("args", ()),
+        exc_info=record_kwargs.pop("exc_info", None),
+    )
+    for key, value in record_kwargs.items():
+        setattr(record, key, value)
+    return json.loads(formatter.format(record))
+
+
+def test_basic_record_has_core_fields() -> None:
+    out = _format_record()
+    assert out["level"] == "INFO"
+    assert out["logger"] == "test"
+    assert out["message"] == "hello"
+    assert "timestamp" in out
+    assert out["timestamp"].endswith("+00:00")  # UTC ISO8601
+
+
+def test_message_args_are_interpolated() -> None:
+    out = _format_record(msg="user=%s", args=("alice",))
+    assert out["message"] == "user=alice"
+
+
+def test_extra_fields_included() -> None:
+    out = _format_record(handler="on_click", path="/page")
+    assert out["handler"] == "on_click"
+    assert out["path"] == "/page"
+
+
+def test_reserved_attrs_not_leaked() -> None:
+    """Internal LogRecord attrs (pathname, lineno, etc.) must not appear
+    as JSON fields — they're noise for log aggregators."""
+    out = _format_record()
+    for key in ("pathname", "lineno", "filename", "funcName", "module"):
+        assert key not in out
+
+
+def test_exception_field_when_exc_info_present() -> None:
+    try:
+        raise ValueError("boom")
+    except ValueError:
+        import sys
+
+        out = _format_record(exc_info=sys.exc_info())
+    assert "exception" in out
+    assert "ValueError" in out["exception"]
+    assert "boom" in out["exception"]
+
+
+def test_non_serialisable_extra_falls_back_safely() -> None:
+    """A bad ``extra=`` shouldn't break logging — formatter falls back."""
+
+    class Unserialisable:
+        def __repr__(self) -> str:
+            return "<U>"
+
+    out = _format_record(weird=Unserialisable())
+    # _coerce uses repr for unknowns; the record still serialises.
+    assert out["weird"] == "<U>"
+
+
+def test_static_fields_merged() -> None:
+    formatter = JSONFormatter(static_fields={"service": "demo", "env": "test"})
+    record = logging.LogRecord(
+        name="x",
+        level=logging.INFO,
+        pathname="/x.py",
+        lineno=1,
+        msg="hi",
+        args=(),
+        exc_info=None,
+    )
+    out = json.loads(formatter.format(record))
+    assert out["service"] == "demo"
+    assert out["env"] == "test"
+
+
+def test_context_vars_pulled_when_set() -> None:
+    """When the framework's context vars are set, they appear in the
+    record automatically — no per-record extra= needed."""
+    from pywire.runtime.observability import (
+        connection_id_ctx,
+        event_id_ctx,
+        request_id_ctx,
+    )
+
+    rid_token = request_id_ctx.set("rid-123")
+    cid_token = connection_id_ctx.set("cid-456")
+    eid_token = event_id_ctx.set("eid-789")
+    try:
+        out = _format_record()
+    finally:
+        request_id_ctx.reset(rid_token)
+        connection_id_ctx.reset(cid_token)
+        event_id_ctx.reset(eid_token)
+    assert out["request_id"] == "rid-123"
+    assert out["connection_id"] == "cid-456"
+    assert out["event_id"] == "eid-789"
+
+
+def test_unset_context_vars_omitted() -> None:
+    out = _format_record()
+    assert "request_id" not in out
+    assert "connection_id" not in out
+    assert "event_id" not in out
+
+
+def test_configure_json_logging_replaces_handlers() -> None:
+    stream = io.StringIO()
+    handler = configure_json_logging(stream=stream)
+    try:
+        logging.getLogger().info("test message", extra={"key": "value"})
+    finally:
+        logging.getLogger().removeHandler(handler)
+
+    line = stream.getvalue().strip().splitlines()[-1]
+    payload = json.loads(line)
+    assert payload["message"] == "test message"
+    assert payload["key"] == "value"
+
+
+def test_configure_json_logging_idempotent() -> None:
+    stream1 = io.StringIO()
+    stream2 = io.StringIO()
+    h1 = configure_json_logging(stream=stream1)
+    h2 = configure_json_logging(stream=stream2)
+    try:
+        logging.getLogger().info("only stream2 should see this")
+    finally:
+        logging.getLogger().removeHandler(h2)
+
+    assert stream1.getvalue() == ""
+    assert "only stream2" in stream2.getvalue()
+    assert h1 is not h2
+
+
+@pytest.mark.parametrize(
+    "level_no,level_name",
+    [
+        (logging.DEBUG, "DEBUG"),
+        (logging.WARNING, "WARNING"),
+        (logging.ERROR, "ERROR"),
+    ],
+)
+def test_levels_serialised(level_no: int, level_name: str) -> None:
+    out = _format_record(level=level_no)
+    assert out["level"] == level_name

--- a/packages/pywire-observability/tests/test_middleware.py
+++ b/packages/pywire-observability/tests/test_middleware.py
@@ -226,7 +226,12 @@ async def test_all_zeros_traceparent_falls_through_to_uuid() -> None:
     sink = _Sink()
     await mw(
         _scope(
-            [(b"traceparent", b"00-00000000000000000000000000000000-b7ad6b7169203331-01")]
+            [
+                (
+                    b"traceparent",
+                    b"00-00000000000000000000000000000000-b7ad6b7169203331-01",
+                )
+            ]
         ),
         _noop_receive,
         sink,

--- a/packages/pywire-observability/tests/test_middleware.py
+++ b/packages/pywire-observability/tests/test_middleware.py
@@ -1,0 +1,210 @@
+"""Tests for ``RequestIDMiddleware``."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from pywire_observability.middleware import (
+    RequestIDMiddleware,
+    _trace_id_from_traceparent,
+)
+
+
+class _RecordingApp:
+    def __init__(self) -> None:
+        self.scope: dict | None = None
+        self.was_called: bool = False
+
+    async def __call__(self, scope: dict, receive: Any, send: Any) -> None:
+        self.scope = scope
+        self.was_called = True
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [(b"content-type", b"text/plain")],
+            }
+        )
+        await send({"type": "http.response.body", "body": b"OK"})
+
+
+class _Sink:
+    def __init__(self) -> None:
+        self.start: dict | None = None
+
+    async def __call__(self, msg: dict) -> None:
+        if msg["type"] == "http.response.start":
+            self.start = msg
+
+
+async def _noop_receive() -> dict:
+    return {"type": "http.request", "body": b"", "more_body": False}
+
+
+def _scope(headers: list[tuple[bytes, bytes]] | None = None) -> dict:
+    return {
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        "headers": headers or [],
+    }
+
+
+@pytest.mark.asyncio
+async def test_generates_id_when_no_inbound_header() -> None:
+    inner = _RecordingApp()
+    mw = RequestIDMiddleware(inner)
+    sink = _Sink()
+    await mw(_scope(), _noop_receive, sink)
+    assert inner.scope is not None
+    rid = inner.scope.get("pywire_request_id")
+    assert rid and len(rid) == 32  # uuid4 hex
+    # Echo header on response.
+    assert sink.start is not None
+    headers = dict(sink.start["headers"])
+    assert headers.get(b"x-request-id") == rid.encode()
+
+
+@pytest.mark.asyncio
+async def test_uses_inbound_x_request_id() -> None:
+    inner = _RecordingApp()
+    mw = RequestIDMiddleware(inner)
+    sink = _Sink()
+    await mw(_scope([(b"x-request-id", b"my-known-id")]), _noop_receive, sink)
+    assert inner.scope and inner.scope["pywire_request_id"] == "my-known-id"
+
+
+@pytest.mark.asyncio
+async def test_traceparent_takes_priority() -> None:
+    inner = _RecordingApp()
+    mw = RequestIDMiddleware(inner)
+    sink = _Sink()
+    trace_id = "0af7651916cd43dd8448eb211c80319c"
+    traceparent = f"00-{trace_id}-b7ad6b7169203331-01"
+    await mw(
+        _scope([(b"traceparent", traceparent.encode()), (b"x-request-id", b"loser")]),
+        _noop_receive,
+        sink,
+    )
+    assert inner.scope and inner.scope["pywire_request_id"] == trace_id
+
+
+@pytest.mark.asyncio
+async def test_malformed_traceparent_falls_through() -> None:
+    inner = _RecordingApp()
+    mw = RequestIDMiddleware(inner)
+    sink = _Sink()
+    await mw(
+        _scope(
+            [
+                (b"traceparent", b"garbage"),
+                (b"x-request-id", b"fallback-value"),
+            ]
+        ),
+        _noop_receive,
+        sink,
+    )
+    assert inner.scope and inner.scope["pywire_request_id"] == "fallback-value"
+
+
+@pytest.mark.asyncio
+async def test_x_correlation_id_used_when_others_absent() -> None:
+    inner = _RecordingApp()
+    mw = RequestIDMiddleware(inner)
+    sink = _Sink()
+    await mw(_scope([(b"x-correlation-id", b"corr-1")]), _noop_receive, sink)
+    assert inner.scope and inner.scope["pywire_request_id"] == "corr-1"
+
+
+@pytest.mark.asyncio
+async def test_websocket_scope_gets_id_no_response_echo() -> None:
+    inner = _RecordingApp()
+    mw = RequestIDMiddleware(inner)
+
+    async def receive() -> dict:
+        return {"type": "websocket.connect"}
+
+    sink = _Sink()
+    await mw({"type": "websocket", "headers": []}, receive, sink)
+    assert inner.scope and inner.scope.get("pywire_request_id")
+
+
+@pytest.mark.asyncio
+async def test_lifespan_passes_through_unchanged() -> None:
+    inner = _RecordingApp()
+    mw = RequestIDMiddleware(inner)
+    sink = _Sink()
+    await mw({"type": "lifespan"}, _noop_receive, sink)
+    assert inner.was_called
+    assert inner.scope is not None
+    assert "pywire_request_id" not in inner.scope
+
+
+@pytest.mark.asyncio
+async def test_request_id_ctx_set_during_handler() -> None:
+    """ContextVar must be live while inner app runs — that's the whole
+    point of the propagation."""
+    from pywire.runtime.observability import request_id_ctx
+
+    captured: dict[str, str | None] = {"id": None}
+
+    class _Capturer:
+        async def __call__(self, scope: dict, receive: Any, send: Any) -> None:
+            captured["id"] = request_id_ctx.get()
+            await send({"type": "http.response.start", "status": 200, "headers": []})
+            await send({"type": "http.response.body", "body": b""})
+
+    mw = RequestIDMiddleware(_Capturer())
+    sink = _Sink()
+    await mw(_scope([(b"x-request-id", b"live-check")]), _noop_receive, sink)
+    assert captured["id"] == "live-check"
+    # And reset after.
+    assert request_id_ctx.get() is None
+
+
+@pytest.mark.asyncio
+async def test_existing_response_x_request_id_preserved() -> None:
+    """If the inner app already set X-Request-ID, the middleware must
+    not overwrite it (an upstream proxy may have echoed something)."""
+
+    class _PrebakedApp:
+        async def __call__(self, scope: dict, receive: Any, send: Any) -> None:
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 200,
+                    "headers": [(b"x-request-id", b"already-set")],
+                }
+            )
+            await send({"type": "http.response.body", "body": b""})
+
+    mw = RequestIDMiddleware(_PrebakedApp())
+    sink = _Sink()
+    await mw(_scope(), _noop_receive, sink)
+    headers = dict(sink.start["headers"])  # type: ignore[arg-type]
+    assert headers[b"x-request-id"] == b"already-set"
+
+
+# --- _trace_id_from_traceparent unit ---
+
+
+@pytest.mark.parametrize(
+    "header,expected",
+    [
+        (
+            "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+            "0af7651916cd43dd8448eb211c80319c",
+        ),
+        (
+            "00-0AF7651916CD43DD8448EB211C80319C-b7ad6b7169203331-01",
+            None,  # uppercase trace_id is invalid per W3C
+        ),
+        ("garbage", None),
+        ("", None),
+        ("00-tooshort-b7ad6b7169203331-01", None),
+    ],
+)
+def test_trace_id_extraction(header: str, expected: str | None) -> None:
+    assert _trace_id_from_traceparent(header) == expected

--- a/packages/pywire-observability/tests/test_middleware.py
+++ b/packages/pywire-observability/tests/test_middleware.py
@@ -204,7 +204,34 @@ async def test_existing_response_x_request_id_preserved() -> None:
         ("garbage", None),
         ("", None),
         ("00-tooshort-b7ad6b7169203331-01", None),
+        (
+            # All-zeros trace_id is W3C-reserved as "invalid". Accepting
+            # it would collapse every misconfigured-upstream request
+            # into a single correlation bucket.
+            "00-00000000000000000000000000000000-b7ad6b7169203331-01",
+            None,
+        ),
     ],
 )
 def test_trace_id_extraction(header: str, expected: str | None) -> None:
     assert _trace_id_from_traceparent(header) == expected
+
+
+@pytest.mark.asyncio
+async def test_all_zeros_traceparent_falls_through_to_uuid() -> None:
+    """An invalid traceparent must NOT become the request_id —
+    fall through to header priority, then UUID4."""
+    inner = _RecordingApp()
+    mw = RequestIDMiddleware(inner)
+    sink = _Sink()
+    await mw(
+        _scope(
+            [(b"traceparent", b"00-00000000000000000000000000000000-b7ad6b7169203331-01")]
+        ),
+        _noop_receive,
+        sink,
+    )
+    assert inner.scope is not None
+    rid = inner.scope["pywire_request_id"]
+    assert rid != "0" * 32
+    assert len(rid) == 32  # generated uuid4 hex

--- a/packages/pywire/pyproject.toml
+++ b/packages/pywire/pyproject.toml
@@ -38,7 +38,7 @@ forms = [
 # that ship pre-compiled artifacts (e.g. Cloudflare Workers via Pyodide
 # where AOT-compiled wheels aren't available) can omit this extra.
 build = [
-    "pywire-parser>=0.8.0",
+    "pywire-parser>=0.7.1",
 ]
 # jinja2 backs the dev-mode compile-error page renderer (error_renderer.py);
 # `pywire run` with debug=False never imports it. It belongs on the dev/cli

--- a/packages/pywire/src/pywire/_compat.py
+++ b/packages/pywire/src/pywire/_compat.py
@@ -18,7 +18,7 @@ from importlib.metadata import PackageNotFoundError, version
 _FLOORS = {
     # pywire-parser is a [build] extra. When installed, must match the
     # AST/directive surface this pywire release was built against.
-    "pywire-parser": "0.8.0",
+    "pywire-parser": "0.7.1",
 }
 
 

--- a/packages/pywire/src/pywire/runtime/app.py
+++ b/packages/pywire/src/pywire/runtime/app.py
@@ -1386,6 +1386,14 @@ class PyWire:
 
     async def _handle_500(self, request: Request, exc: Exception) -> Response:
         """Handle 500 errors with custom page if available."""
+        # Log the underlying exception so log aggregators / Sentry / OTel
+        # see the failure even when the custom error page hides the
+        # message from end users in prod.
+        logger.exception(
+            "Unhandled exception in page render",
+            extra={"path": request.url.path},
+        )
+
         # Try to find /__error__ page
         match = self.router.match("/__error__")
 
@@ -1407,10 +1415,10 @@ class PyWire:
                 # Force 500 status
                 response.status_code = 500
                 return response
-            except Exception as e:
-                # If 500 page fails, fall back
-                print(f"Error rendering 500 page: {e}")
-                pass
+            except Exception:
+                # If 500 page fails, log it too and fall back. This
+                # branch is rare — the error page itself exploded.
+                logger.exception("Failed to render custom 500 error page")
 
         # If no custom page or it failed:
         if self.debug:

--- a/packages/pywire/src/pywire/runtime/observability.py
+++ b/packages/pywire/src/pywire/runtime/observability.py
@@ -1,0 +1,38 @@
+"""Request-scoped observability primitives.
+
+Three :class:`contextvars.ContextVar` instances that propagate identity
+through the request lifecycle:
+
+- :data:`request_id_ctx` — set once per HTTP request or once per WS
+  connection lifetime. Identifies a single user-driven action chain.
+- :data:`connection_id_ctx` — set once per WebSocket connection.
+  Same value for every event on the connection.
+- :data:`event_id_ctx` — set per WS event handler call. Lets logs
+  correlate a specific click/submit within a longer connection.
+
+Background tasks spawned via :func:`asyncio.create_task` inherit the
+ContextVar values present at task-creation time (Python 3.7+ stdlib
+behavior). Spawn tasks before the originating handler's ``finally``
+block resets context to keep the IDs flowing into the task.
+
+These primitives are intentionally pure stdlib — :mod:`pywire-observability`
+reads them to populate JSON log records and produce request-scoped
+spans, but the framework sets them with no extra dependency.
+"""
+
+from __future__ import annotations
+
+import contextvars
+from typing import Optional
+
+request_id_ctx: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+    "pywire_request_id", default=None
+)
+
+connection_id_ctx: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+    "pywire_connection_id", default=None
+)
+
+event_id_ctx: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+    "pywire_event_id", default=None
+)

--- a/packages/pywire/src/pywire/runtime/page.py
+++ b/packages/pywire/src/pywire/runtime/page.py
@@ -204,6 +204,13 @@ class BasePage:
             self._style_collector = StyleCollector()
 
         self.user: Any = None  # Set by middleware
+        # Set by pywire-observability's RequestIDMiddleware (via scope)
+        # when installed. Defaults to "" so templates using
+        # {request_id} render harmlessly without observability wired up.
+        scope = getattr(request, "scope", None) if request is not None else None
+        self.request_id: str = (
+            (scope.get("pywire_request_id", "") or "") if scope else ""
+        )
 
         # Expose params as attributes for easy access in templates
         for k, v in self.params.items():

--- a/packages/pywire/src/pywire/runtime/websocket.py
+++ b/packages/pywire/src/pywire/runtime/websocket.py
@@ -593,9 +593,7 @@ class WebSocketHandler:
 
             # Call handler
             if handler_name:
-                update = await page.handle_event(
-                    cast(str, handler_name), event_data
-                )
+                update = await page.handle_event(cast(str, handler_name), event_data)
             else:
                 update = await page.render_update(init=False)
 

--- a/packages/pywire/src/pywire/runtime/websocket.py
+++ b/packages/pywire/src/pywire/runtime/websocket.py
@@ -30,6 +30,10 @@ class WebSocketHandler:
         self.connection_pages: Dict[WebSocket, BasePage] = {}
         # Map websocket to session ID for state persistence
         self.session_ids: Dict[WebSocket, str] = {}
+        # Map websocket to its observability connection_id (one per WS,
+        # surviving the lifetime of the socket — used to correlate logs
+        # and OTel spans across multiple events on the same connection).
+        self.connection_ids: Dict[WebSocket, str] = {}
         # Map websocket to its ping loop task
         self._ping_tasks: Dict[WebSocket, asyncio.Task[None]] = {}
         # Track pending pong events per connection
@@ -75,6 +79,16 @@ class WebSocketHandler:
         await websocket.accept()
         self.active_connections.add(websocket)
 
+        # Mint a connection id for the lifetime of this WS. Surfaced via
+        # the connection_id_ctx ContextVar so JSON log records and OTel
+        # spans can correlate every event on the same socket. Using uuid4
+        # keeps this stdlib-only — no observability dep needed in core.
+        from pywire.runtime.observability import connection_id_ctx
+
+        connection_id = uuid.uuid4().hex
+        self.connection_ids[websocket] = connection_id
+        conn_token = connection_id_ctx.set(connection_id)
+
         # Send init message
         await websocket.send_bytes(
             msgpack.packb({"type": "init", "version": __version__})
@@ -99,10 +113,10 @@ class WebSocketHandler:
         except asyncio.CancelledError:
             # Server shutdown, clean disconnect — don't re-raise
             pass
-        except Exception as e:
-            print(f"WebSocket error: {e}")
-            traceback.print_exc()
+        except Exception:
+            logger.exception("WebSocket connection error")
         finally:
+            connection_id_ctx.reset(conn_token)
             self._cleanup_connection(websocket)
 
     async def _resolve_user(self, websocket: WebSocket) -> Any:
@@ -238,6 +252,7 @@ class WebSocketHandler:
         self._connection_in_error.discard(websocket)
         # Keep session in store (TTL handles cleanup) — enables reconnect
         self.session_ids.pop(websocket, None)
+        self.connection_ids.pop(websocket, None)
         self._connection_cookies.pop(websocket, None)
         self._connection_httponly.pop(websocket, None)
         self._connection_reconciled.discard(websocket)
@@ -520,9 +535,7 @@ class WebSocketHandler:
             await page._run_hooks(page.MOUNT_HOOKS)
 
         except Exception as e:
-            import traceback
-
-            traceback.print_exc()
+            logger.exception("WebSocket init failed")
             await self._send_error_trace(websocket, e)
         finally:
             log_callback_ctx.reset(token)
@@ -540,6 +553,12 @@ class WebSocketHandler:
 
         # Set context for this operation
         token = log_callback_ctx.set(send_log)
+        # Mint a per-event id so log records emitted while this handler
+        # runs (and any background tasks it spawns) carry an event_id
+        # alongside the long-lived connection_id. Reset in finally.
+        from pywire.runtime.observability import event_id_ctx
+
+        event_token = event_id_ctx.set(uuid.uuid4().hex)
 
         try:
             # Get or create page instance
@@ -604,13 +623,14 @@ class WebSocketHandler:
                 self._persist_session(session_id, page)
 
         except Exception as e:
-            # Send structured trace to client (no print - trace is sufficient)
-            import traceback
-
-            traceback.print_exc()
+            logger.exception(
+                "WebSocket event handler failed",
+                extra={"handler": handler_name, "path": path},
+            )
             await self._send_error_trace(websocket, e)
         finally:
             log_callback_ctx.reset(token)
+            event_id_ctx.reset(event_token)
 
     async def _handle_relocate(
         self, websocket: WebSocket, data: Dict[str, Any]

--- a/packages/pywire/src/pywire/runtime/websocket.py
+++ b/packages/pywire/src/pywire/runtime/websocket.py
@@ -592,15 +592,12 @@ class WebSocketHandler:
             page._on_update = broadcast_update
 
             # Call handler
-            try:
-                if handler_name:
-                    update = await page.handle_event(
-                        cast(str, handler_name), event_data
-                    )
-                else:
-                    update = await page.render_update(init=False)
-            except Exception as e:
-                raise e
+            if handler_name:
+                update = await page.handle_event(
+                    cast(str, handler_name), event_data
+                )
+            else:
+                update = await page.render_update(init=False)
 
             # Check for pending navigation
             if page._pending_navigation:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ workspace = { members = [
     "packages/pywire",
     "packages/pywire-auth",
     "packages/pywire-cli",
+    "packages/pywire-observability",
     "packages/pywire-language-server",
     "packages/pywire-parser",
     "packages/pywire-templates",
@@ -30,6 +31,7 @@ workspace = { members = [
 pywire = { workspace = true }
 pywire-auth = { workspace = true }
 pywire-cli = { workspace = true }
+pywire-observability = { workspace = true }
 pywire-language-server = { workspace = true }
 pywire-parser = { workspace = true }
 pywire-templates = { workspace = true }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -16,6 +16,10 @@
       "release-type": "python",
       "component": "pywire-auth"
     },
+    "packages/pywire-observability": {
+      "release-type": "python",
+      "component": "pywire-observability"
+    },
     "packages/pywire-cli": {
       "release-type": "python",
       "component": "pywire-cli"

--- a/uv.lock
+++ b/uv.lock
@@ -18,6 +18,7 @@ members = [
     "pywire-cli",
     "pywire-language-server",
     "pywire-monorepo",
+    "pywire-observability",
     "pywire-parser",
     "pywire-templates",
     "tree-sitter-pywire",
@@ -1857,7 +1858,7 @@ wheels = [
 
 [[package]]
 name = "pywire"
-version = "0.14.2"
+version = "0.14.3"
 source = { editable = "packages/pywire" }
 dependencies = [
     { name = "msgpack" },
@@ -2021,7 +2022,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "pywire-language-server"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "packages/pywire-language-server" }
 dependencies = [
     { name = "pygls" },
@@ -2077,8 +2078,34 @@ requires-dist = [
 ]
 
 [[package]]
+name = "pywire-observability"
+version = "0.1.0"
+source = { editable = "packages/pywire-observability" }
+dependencies = [
+    { name = "pywire" },
+    { name = "starlette" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "httpx" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.25" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21" },
+    { name = "pywire", editable = "packages/pywire" },
+    { name = "starlette", specifier = ">=0.31" },
+]
+provides-extras = ["dev"]
+
+[[package]]
 name = "pywire-parser"
-version = "0.8.0"
+version = "0.7.1"
 source = { editable = "packages/pywire-parser" }
 dependencies = [
     { name = "tree-sitter" },


### PR DESCRIPTION
## Summary

New `pywire-observability` package: production-grade observability seams for PyWire apps. Single-call install via `connect_observability(app, ...)`. .NET-style hybrid: minimum primitives in core, batteries in the separate package.

- **Request-ID propagation** — `RequestIDMiddleware` reads W3C `traceparent` (rejects all-zeros per spec §2.2.3), then `x-request-id`, then `x-correlation-id`; UUID4 fallback. Propagates via `request_id_ctx` ContextVar through HTTP, WebSocket, and background tasks. Echoes back as `X-Request-ID`.
- **JSON logging** — `JSONFormatter` + `configure_json_logging()` drop in compatible with Datadog, ELK, Loki, CloudWatch, Cloud Logging, Azure Monitor. Auto-injects request/connection/event ID context. Cycle-safe (`_MAX_COERCE_DEPTH`). Idempotent reconfigure via marker. Warns when destroying foreign root handlers.
- **OpenTelemetry** — `pywire_observability.otel.instrument(app)` wraps `StarletteInstrumentor` with the ASGI internal-replay filter pre-installed.
- **Sentry** — `pywire_observability.sentry.init(...)` configures `LoggingIntegration` + `StarletteIntegration` with a `before_send` hook tagging events with PyWire request/connection/event IDs.

## Core changes (`pywire`)

- New `pywire.runtime.observability` module: `request_id_ctx`, `connection_id_ctx`, `event_id_ctx` ContextVars. Pure stdlib, no deps.
- `BasePage.request_id: str` attribute (parallels `csrf_token`/`user`).
- `WebSocketHandler` mints a connection-ID at accept time, sets `connection_id_ctx` for the WS lifetime, and an event-ID per `_handle_event` call.
- Error-logging fixes: `_handle_500` and three WS handler paths replaced `print` + `traceback.print_exc()` with `logger.exception(...)` so failures actually reach log aggregators / Sentry. Removed a dead `try/except: raise` wrapper in `_handle_event`.

## CLI

`pywire dev --log-format=json` and `pywire run --log-format=json`. Sets `PYWIRE_LOG_FORMAT=json` so uvicorn workers (fresh interpreter) inherit the choice and reconfigure on import.

## Language server

Unconditional `request_id: str` stub in framework stubs.

## Tests

41 new tests on pywire-observability + full pywire core suite green.

## Files

```
packages/pywire-observability/                     (new package)
packages/pywire/src/pywire/runtime/observability.py (new)
packages/pywire/src/pywire/runtime/page.py          (request_id attr)
packages/pywire/src/pywire/runtime/app.py           (logger.exception in _handle_500)
packages/pywire/src/pywire/runtime/websocket.py     (conn/event IDs + logger.exception)
packages/pywire-cli/src/pywire_cli/main.py          (--log-format flag)
packages/pywire-language-server/.../transpiler.py   (request_id stub)
release-please-config.json + manifest               (workspace registration)
.github/workflows/ci.yml + release.yml              (per-package jobs)
pyproject.toml + uv.lock                            (workspace member)
```

## Version floors

`pywire-observability>=0.1.0` requires `pywire>=0.15.0` — the observability ContextVars and `BasePage.request_id` ship in pywire 0.15.0 alongside this package's first release. Both pyproject and runtime `_compat.py` floors set in lockstep per CLAUDE.md.

## Out of scope (filed)

- #254 per-WS-event OTel spans
- #255 Prometheus / OTel meter metrics
- #256 distributed-tracing-aware page-state snapshots
- #257 bundled OTel/Sentry extras

## Test plan

- [x] `cd packages/pywire-observability && uv run --extra dev pytest -q` — 41 passing
- [x] `cd packages/pywire && uv run pytest -q` — full suite green
- [x] All-zeros traceparent falls through to UUID
- [x] Cyclic `extra=` dict does not raise `RecursionError`
- [x] Idempotent `configure_json_logging` does not re-warn on self-replace
- [ ] Smoke against `examples/demo-app` with `connect_observability(app)` enabled and `--log-format=json`